### PR TITLE
fix(scheduler): extend cron search window to 32 days

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lsh-framework",
-  "version": "3.1.23",
+  "version": "3.1.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lsh-framework",
-      "version": "3.1.23",
+      "version": "3.1.24",
       "license": "MIT",
       "dependencies": {
         "@supabase/supabase-js": "^2.57.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lsh-framework",
-  "version": "3.1.23",
+  "version": "3.1.24",
   "description": "Simple, cross-platform encrypted secrets manager with automatic sync, IPFS audit logs, and multi-environment support. Just run lsh sync and start managing your secrets.",
   "main": "dist/app.js",
   "bin": {

--- a/src/lib/optimized-job-scheduler.ts
+++ b/src/lib/optimized-job-scheduler.ts
@@ -312,8 +312,9 @@ export class OptimizedJobScheduler extends EventEmitter {
       const [minute, hour, day, month, weekday] = cronExpr.split(' ');
       const now = new Date(from);
 
-      // Try to find next matching time within the next 7 days
-      for (let i = 0; i < 7 * 24 * 60; i++) {
+      // Try to find next matching time within the next 32 days
+      // (covers monthly cron expressions like "0 0 1 * *")
+      for (let i = 0; i < 32 * 24 * 60; i++) {
         const checkTime = new Date(now.getTime() + i * 60000);
 
         if (

--- a/types/daemon/lshd.d.ts
+++ b/types/daemon/lshd.d.ts
@@ -47,6 +47,7 @@ export declare class LSHJobDaemon extends EventEmitter {
     private lastRunTimes;
     private logger;
     private optimizedScheduler?;
+    private startupProfiler?;
     constructor(config?: Partial<DaemonConfig>);
     /**
      * Initialize the optimized job scheduler (Issue #108)


### PR DESCRIPTION
## Summary
- Extended cron job scheduler search window from 7 days to 32 days
- Fixes monthly cron expressions like `0 0 1 * *` (first of month) that failed when the next occurrence was more than 7 days away
- Bumped version to 3.1.24

## Problem
The `getNextCronRun` function only searched 7 days into the future, which caused monthly cron expressions to return `null` and jobs to not be added to the scheduler.

## Solution
Extended the search window to 32 days to properly handle monthly cron expressions.

## Test plan
- [x] All existing tests pass
- [x] Verified the fix locally by testing monthly cron expression `0 0 1 * *`

## Summary by Sourcery

Extend the cron-based job scheduler’s search window to handle monthly schedules and bump the package version.

Bug Fixes:
- Ensure cron jobs with monthly-like expressions are scheduled correctly by expanding the future search window.

Enhancements:
- Increase the cron search window from 7 to 32 days to better support less frequent schedules.
- Extend the LSH job daemon type definition to include the optional startup profiler field.

Build:
- Bump package version from 3.1.23 to 3.1.24.