### PR TITLE
fix(ci): make publish workflow idempotent

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,9 @@
 # Automated NPM Publishing on Version Tags
 # Uses npm Trusted Publishing (OIDC) - no NPM_TOKEN required
+#
+# This workflow is idempotent - it can be safely re-run without failing:
+# - Skips npm publish if version already exists on npm
+# - Skips GitHub release creation if release already exists
 name: Publish to npm
 
 on:
@@ -35,12 +39,51 @@ jobs:
     - name: Run tests
       run: npm test -- --forceExit
 
+    - name: Get package info
+      id: package
+      run: |
+        PACKAGE_NAME=$(node -p "require('./package.json').name")
+        PACKAGE_VERSION=$(node -p "require('./package.json').version")
+        echo "name=$PACKAGE_NAME" >> $GITHUB_OUTPUT
+        echo "version=$PACKAGE_VERSION" >> $GITHUB_OUTPUT
+
+    - name: Check if version exists on npm
+      id: npm_check
+      run: |
+        if npm view "${{ steps.package.outputs.name }}@${{ steps.package.outputs.version }}" version 2>/dev/null; then
+          echo "exists=true" >> $GITHUB_OUTPUT
+          echo "Version ${{ steps.package.outputs.version }} already exists on npm"
+        else
+          echo "exists=false" >> $GITHUB_OUTPUT
+          echo "Version ${{ steps.package.outputs.version }} does not exist on npm - will publish"
+        fi
+
     - name: Publish to npm
+      if: steps.npm_check.outputs.exists == 'false'
       run: npm publish --provenance --access public
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+    - name: Skip publish (already exists)
+      if: steps.npm_check.outputs.exists == 'true'
+      run: echo "Skipping npm publish - version ${{ steps.package.outputs.version }} already exists"
+
+    - name: Check if GitHub release exists
+      id: release_check
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        TAG_NAME="${GITHUB_REF#refs/tags/}"
+        if gh release view "$TAG_NAME" &>/dev/null; then
+          echo "exists=true" >> $GITHUB_OUTPUT
+          echo "GitHub release $TAG_NAME already exists"
+        else
+          echo "exists=false" >> $GITHUB_OUTPUT
+          echo "GitHub release $TAG_NAME does not exist - will create"
+        fi
+
     - name: Create GitHub Release
+      if: steps.release_check.outputs.exists == 'false'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
@@ -57,3 +100,28 @@ jobs:
         # or
         lsh self update
         \`\`\`"
+
+    - name: Skip release (already exists)
+      if: steps.release_check.outputs.exists == 'true'
+      run: |
+        TAG_NAME="${GITHUB_REF#refs/tags/}"
+        echo "Skipping GitHub release - $TAG_NAME already exists"
+
+    - name: Summary
+      run: |
+        echo "## Publish Summary" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "| Item | Status |" >> $GITHUB_STEP_SUMMARY
+        echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
+        if [ "${{ steps.npm_check.outputs.exists }}" == "true" ]; then
+          echo "| npm publish | ⏭️ Skipped (already exists) |" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "| npm publish | ✅ Published |" >> $GITHUB_STEP_SUMMARY
+        fi
+        if [ "${{ steps.release_check.outputs.exists }}" == "true" ]; then
+          echo "| GitHub release | ⏭️ Skipped (already exists) |" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "| GitHub release | ✅ Created |" >> $GITHUB_STEP_SUMMARY
+        fi
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "**Package:** ${{ steps.package.outputs.name }}@${{ steps.package.outputs.version }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Add pre-checks to skip npm publish if version already exists
- Add pre-checks to skip GitHub release if it already exists
- Add summary step showing what actions were taken
- Document idempotency in workflow comments

## Problem
The publish workflow was failing with E403 when re-run because:
1. `npm publish` fails if the version already exists on npm
2. When npm publish fails, the workflow exits before creating the GitHub release
3. This left versions published to npm but without corresponding GitHub releases

## Solution
Make the workflow idempotent by:
1. Checking if npm version exists before attempting publish
2. Checking if GitHub release exists before creating
3. Skipping steps gracefully when artifacts already exist
4. Adding a summary step for visibility

## Test plan
- [x] Workflow syntax validated
- [ ] Re-run the publish workflow for an existing version (e.g., v3.1.24) to verify it completes successfully with skipped steps

## Summary by Sourcery

Make the npm publish GitHub workflow idempotent so it can be safely re-run without failing when artifacts already exist.

Enhancements:
- Add checks to skip npm publish when the package version already exists on npm.
- Add checks to skip GitHub release creation when a release for the tag already exists.
- Add a summary step that reports whether publish and release steps were executed or skipped.
- Document the workflow's idempotent behavior in comments within the workflow file.