### PR TITLE
feat(ipns): deterministic IPNS auto-sync from LSH_SECRETS_KEY

### DIFF
--- a/__tests__/ipns-key-manager.test.ts
+++ b/__tests__/ipns-key-manager.test.ts
@@ -1,0 +1,96 @@
+/**
+ * IPNS Key Manager Tests
+ * Unit tests for deterministic key derivation (no network required)
+ */
+
+import * as crypto from 'crypto';
+import { describe, it, expect } from '@jest/globals';
+import { deriveKeyInfo, buildPemFromSeed } from '../src/lib/ipns-key-manager.js';
+
+describe('IPNSKeyManager', () => {
+  const testKey = 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
+  const testRepo = 'my-app';
+  const testEnv = 'dev';
+
+  describe('deriveKeyInfo', () => {
+    it('should return deterministic results for same inputs', () => {
+      const result1 = deriveKeyInfo(testKey, testRepo, testEnv);
+      const result2 = deriveKeyInfo(testKey, testRepo, testEnv);
+
+      expect(result1.keyName).toBe(result2.keyName);
+      expect(result1.seed.equals(result2.seed)).toBe(true);
+    });
+
+    it('should produce different keys for different secrets keys', () => {
+      const result1 = deriveKeyInfo(testKey, testRepo, testEnv);
+      const result2 = deriveKeyInfo('different-key', testRepo, testEnv);
+
+      expect(result1.keyName).not.toBe(result2.keyName);
+      expect(result1.seed.equals(result2.seed)).toBe(false);
+    });
+
+    it('should produce different keys for different repos', () => {
+      const result1 = deriveKeyInfo(testKey, 'repo-a', testEnv);
+      const result2 = deriveKeyInfo(testKey, 'repo-b', testEnv);
+
+      expect(result1.keyName).not.toBe(result2.keyName);
+    });
+
+    it('should produce different keys for different environments', () => {
+      const result1 = deriveKeyInfo(testKey, testRepo, 'dev');
+      const result2 = deriveKeyInfo(testKey, testRepo, 'prod');
+
+      expect(result1.keyName).not.toBe(result2.keyName);
+    });
+
+    it('should produce a 32-byte seed', () => {
+      const result = deriveKeyInfo(testKey, testRepo, testEnv);
+      expect(result.seed.length).toBe(32);
+    });
+
+    it('should produce a key name with lsh- prefix and 20 chars total', () => {
+      const result = deriveKeyInfo(testKey, testRepo, testEnv);
+      expect(result.keyName).toMatch(/^lsh-[0-9a-f]{16}$/);
+      expect(result.keyName.length).toBe(20);
+    });
+  });
+
+  describe('buildPemFromSeed', () => {
+    it('should produce a valid PEM string', () => {
+      const { seed } = deriveKeyInfo(testKey, testRepo, testEnv);
+      const pem = buildPemFromSeed(seed);
+
+      expect(pem).toContain('-----BEGIN PRIVATE KEY-----');
+      expect(pem).toContain('-----END PRIVATE KEY-----');
+    });
+
+    it('should produce a valid ed25519 key that Node.js crypto can parse', () => {
+      const { seed } = deriveKeyInfo(testKey, testRepo, testEnv);
+      const pem = buildPemFromSeed(seed);
+
+      // Should not throw
+      const keyObject = crypto.createPrivateKey(pem);
+      expect(keyObject.type).toBe('private');
+      expect(keyObject.asymmetricKeyType).toBe('ed25519');
+    });
+
+    it('should produce deterministic PEM for same seed', () => {
+      const { seed } = deriveKeyInfo(testKey, testRepo, testEnv);
+      const pem1 = buildPemFromSeed(seed);
+      const pem2 = buildPemFromSeed(seed);
+
+      expect(pem1).toBe(pem2);
+    });
+
+    it('should produce a public key that can be derived from the private key', () => {
+      const { seed } = deriveKeyInfo(testKey, testRepo, testEnv);
+      const pem = buildPemFromSeed(seed);
+
+      const privateKey = crypto.createPrivateKey(pem);
+      const publicKey = crypto.createPublicKey(privateKey);
+
+      expect(publicKey.type).toBe('public');
+      expect(publicKey.asymmetricKeyType).toBe('ed25519');
+    });
+  });
+});

--- a/__tests__/ipns-key-manager.test.ts
+++ b/__tests__/ipns-key-manager.test.ts
@@ -8,7 +8,7 @@ import { describe, it, expect } from '@jest/globals';
 import { deriveKeyInfo, buildPemFromSeed } from '../src/lib/ipns-key-manager.js';
 
 describe('IPNSKeyManager', () => {
-  const testKey = 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
+  const testKey = 'test-key-for-unit-tests-not-a-real-secret';
   const testRepo = 'my-app';
   const testEnv = 'dev';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lsh-framework",
-  "version": "3.1.26",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lsh-framework",
-      "version": "3.1.26",
+      "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
         "@supabase/supabase-js": "^2.57.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lsh-framework",
-  "version": "3.1.26",
+  "version": "3.2.0",
   "description": "Simple, cross-platform encrypted secrets manager with automatic sync, IPFS audit logs, and multi-environment support. Just run lsh sync and start managing your secrets.",
   "main": "dist/app.js",
   "bin": {

--- a/src/commands/ipfs.ts
+++ b/src/commands/ipfs.ts
@@ -8,6 +8,9 @@ import chalk from 'chalk';
 import ora from 'ora';
 import { IPFSClientManager } from '../lib/ipfs-client-manager.js';
 import { getIPFSSync } from '../lib/ipfs-sync.js';
+import { deriveKeyInfo, ensureKeyImported } from '../lib/ipns-key-manager.js';
+import { getGitRepoInfo } from '../lib/git-utils.js';
+import { ENV_VARS, DEFAULTS } from '../constants/index.js';
 
 /**
  * Register IPFS commands
@@ -71,6 +74,31 @@ export function registerIPFSCommands(program: Command): void {
         }
         console.log('');
 
+        // IPNS info
+        const encryptionKey = process.env[ENV_VARS.LSH_SECRETS_KEY];
+        if (encryptionKey && daemonInfo) {
+          console.log(chalk.bold('IPNS:'));
+          try {
+            const gitInfo = getGitRepoInfo();
+            const repoName = gitInfo?.repoName || DEFAULTS.DEFAULT_ENVIRONMENT;
+            const keyInfo = deriveKeyInfo(encryptionKey, repoName, DEFAULTS.DEFAULT_ENVIRONMENT);
+            const ipnsName = await ensureKeyImported(ipfsSync.getApiUrl(), keyInfo);
+
+            if (ipnsName) {
+              console.log(chalk.green(`  ✅ IPNS name: ${ipnsName}`));
+              const resolvedCid = await ipfsSync.resolveIPNS(ipnsName);
+              if (resolvedCid) {
+                console.log(`     Latest CID: ${resolvedCid.substring(0, 20)}...`);
+              } else {
+                console.log(chalk.gray('     No published record yet'));
+              }
+            }
+          } catch {
+            console.log(chalk.gray('  Could not derive IPNS info'));
+          }
+          console.log('');
+        }
+
         // Quick actions
         console.log(chalk.bold('Quick Actions:'));
         if (!info.installed) {
@@ -78,8 +106,8 @@ export function registerIPFSCommands(program: Command): void {
         } else if (!daemonInfo) {
           console.log(chalk.cyan('  lsh ipfs start       # Start daemon'));
         } else {
-          console.log(chalk.cyan('  lsh ipfs sync push   # Upload encrypted secrets'));
-          console.log(chalk.cyan('  lsh ipfs sync pull <cid>  # Download by CID'));
+          console.log(chalk.cyan('  lsh sync push        # Push secrets'));
+          console.log(chalk.cyan('  lsh sync pull        # Pull latest via IPNS'));
         }
         console.log('');
       } catch (error) {

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -14,7 +14,8 @@ import * as crypto from 'crypto';
 import { getIPFSSync } from '../lib/ipfs-sync.js';
 import { IPFSClientManager } from '../lib/ipfs-client-manager.js';
 import { getGitRepoInfo } from '../lib/git-utils.js';
-import { ENV_VARS } from '../constants/index.js';
+import { deriveKeyInfo, ensureKeyImported } from '../lib/ipns-key-manager.js';
+import { ENV_VARS, DEFAULTS } from '../constants/index.js';
 
 /**
  * Register sync commands
@@ -266,8 +267,30 @@ export function registerSyncCommands(program: Command): void {
         if (options.description) {
           console.log(chalk.bold('Description:'), chalk.gray(options.description));
         }
+
+        // Publish to IPNS
+        if (encryptionKey) {
+          try {
+            const repoName = gitInfo?.repoName || DEFAULTS.DEFAULT_ENVIRONMENT;
+            const env = options.env || DEFAULTS.DEFAULT_ENVIRONMENT;
+            const keyInfo = deriveKeyInfo(encryptionKey, repoName, env);
+            const ipnsName = await ensureKeyImported(ipfsSync.getApiUrl(), keyInfo);
+
+            if (ipnsName) {
+              const publishedName = await ipfsSync.publishToIPNS(cid, keyInfo.keyName);
+              if (publishedName) {
+                console.log(chalk.bold('IPNS:'), chalk.cyan(publishedName));
+              }
+            }
+          } catch {
+            // Non-fatal: IPNS is a convenience
+          }
+        }
+
         console.log('');
         console.log(chalk.gray('Pull on another machine:'));
+        console.log(chalk.cyan('  lsh sync pull'));
+        console.log(chalk.gray('Or by specific CID:'));
         console.log(chalk.cyan(`  lsh sync pull ${cid}`));
         console.log('');
       } catch (error) {
@@ -363,14 +386,31 @@ export function registerSyncCommands(program: Command): void {
         spinner.succeed(chalk.green('Uploaded to IPFS!'));
         console.log('');
         console.log(chalk.bold('CID:'), chalk.cyan(cid));
+
+        // Publish to IPNS
+        if (encryptionKey) {
+          try {
+            const repoName = gitInfo?.repoName || DEFAULTS.DEFAULT_ENVIRONMENT;
+            const env = options.env || DEFAULTS.DEFAULT_ENVIRONMENT;
+            const keyInfo = deriveKeyInfo(encryptionKey, repoName, env);
+            const ipnsName = await ensureKeyImported(ipfsSync.getApiUrl(), keyInfo);
+
+            if (ipnsName) {
+              const publishedName = await ipfsSync.publishToIPNS(cid, keyInfo.keyName);
+              if (publishedName) {
+                console.log(chalk.bold('IPNS:'), chalk.cyan(publishedName));
+              }
+            }
+          } catch {
+            // Non-fatal
+          }
+        }
+
         console.log('');
-        console.log(chalk.gray('Share this CID with teammates to pull secrets:'));
+        console.log(chalk.gray('Teammates can pull with just:'));
+        console.log(chalk.cyan('  lsh sync pull'));
+        console.log(chalk.gray('Or by specific CID:'));
         console.log(chalk.cyan(`  lsh sync pull ${cid}`));
-        console.log('');
-        console.log(chalk.gray('Public gateway URLs:'));
-        ipfsSync.getGatewayUrls(cid).slice(0, 2).forEach(url => {
-          console.log(chalk.gray(`  ${url}`));
-        });
         console.log('');
       } catch (error) {
         const err = error as Error;
@@ -380,14 +420,75 @@ export function registerSyncCommands(program: Command): void {
       }
     });
 
-  // lsh sync pull <cid>
+  // lsh sync pull [cid]
   syncCommand
-    .command('pull <cid>')
-    .description('⬇️  Pull secrets from IPFS by CID')
+    .command('pull [cid]')
+    .description('⬇️  Pull secrets from IPFS (auto-resolves via IPNS if no CID given)')
     .option('-o, --output <path>', 'Output file path', '.env')
+    .option('-e, --env <name>', 'Environment name', '')
     .option('--force', 'Overwrite existing file without backup')
     .action(async (cid, options) => {
-      const spinner = ora('Downloading from IPFS...').start();
+      const spinner = ora(cid ? 'Downloading from IPFS...' : 'Resolving latest secrets via IPNS...').start();
+
+      // If no CID provided, resolve via IPNS
+      if (!cid) {
+        try {
+          const ipfsSync = getIPFSSync();
+          if (!await ipfsSync.checkDaemon()) {
+            spinner.fail(chalk.red('IPFS daemon not running'));
+            console.log(chalk.gray('  Start with: lsh sync start'));
+            process.exit(1);
+          }
+
+          // Get encryption key
+          let ipnsKey = process.env[ENV_VARS.LSH_SECRETS_KEY];
+          if (!ipnsKey) {
+            const outputPath = path.resolve(options.output);
+            if (fs.existsSync(outputPath)) {
+              const content = fs.readFileSync(outputPath, 'utf-8');
+              const keyMatch = content.match(/^LSH_SECRETS_KEY=(.+)$/m);
+              if (keyMatch) {
+                ipnsKey = keyMatch[1].trim().replace(/^["']|["']$/g, '');
+              }
+            }
+          }
+
+          if (!ipnsKey) {
+            spinner.fail(chalk.red('LSH_SECRETS_KEY required for IPNS resolution'));
+            console.log(chalk.gray('  Set it: export LSH_SECRETS_KEY=<key>'));
+            process.exit(1);
+          }
+
+          const gitInfo = getGitRepoInfo();
+          const repoName = gitInfo?.repoName || DEFAULTS.DEFAULT_ENVIRONMENT;
+          const environment = options.env || DEFAULTS.DEFAULT_ENVIRONMENT;
+          const keyInfo = deriveKeyInfo(ipnsKey, repoName, environment);
+          const ipnsName = await ensureKeyImported(ipfsSync.getApiUrl(), keyInfo);
+
+          if (!ipnsName) {
+            spinner.fail(chalk.red('Failed to derive IPNS key'));
+            process.exit(1);
+          }
+
+          spinner.text = `Resolving IPNS: ${ipnsName.substring(0, 20)}...`;
+          const resolvedCid = await ipfsSync.resolveIPNS(ipnsName);
+
+          if (!resolvedCid) {
+            spinner.fail(chalk.red('No secrets found via IPNS'));
+            console.log(chalk.gray('  No one has pushed secrets for this repo/environment yet.'));
+            console.log(chalk.gray('  Push first: lsh sync push'));
+            process.exit(1);
+          }
+
+          cid = resolvedCid;
+          spinner.succeed(chalk.green(`Resolved IPNS → CID: ${cid.substring(0, 16)}...`));
+          spinner.start('Downloading from IPFS...');
+        } catch (error) {
+          const err = error as Error;
+          spinner.fail(chalk.red(`IPNS resolution failed: ${err.message}`));
+          process.exit(1);
+        }
+      }
 
       try {
         const ipfsSync = getIPFSSync();

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -161,4 +161,11 @@ export const DEFAULTS = {
   DEFAULT_SHELL_UNIX: '/bin/sh',
   DEFAULT_SHELL_WIN: 'cmd.exe',
   DEFAULT_EDITOR: 'vi',
+
+  // IPNS configuration
+  DEFAULT_ENVIRONMENT: 'default',
+  IPNS_PUBLISH_LIFETIME: '87600h',       // ~10 years, re-published on each push
+  IPNS_RESOLVE_TIMEOUT_MS: 30000,        // 30s for DHT lookup
+  IPNS_KEY_PREFIX: 'lsh-',
+  IPNS_KEY_DERIVATION_CONTEXT: 'lsh-ipns-v1',
 } as const;

--- a/src/lib/ipfs-client-manager.ts
+++ b/src/lib/ipfs-client-manager.ts
@@ -300,7 +300,7 @@ export class IPFSClientManager {
       } catch {
         // Daemon not ready yet, keep polling
       }
-      await new Promise(resolve => setTimeout(resolve, 500));
+      await new Promise<void>(resolve => { setTimeout(resolve, 500); });
     }
     return false;
   }

--- a/src/lib/ipfs-secrets-storage.ts
+++ b/src/lib/ipfs-secrets-storage.ts
@@ -16,7 +16,8 @@ import * as crypto from 'crypto';
 import { Secret } from './secrets-manager.js';
 import { createLogger } from './logger.js';
 import { getIPFSSync } from './ipfs-sync.js';
-import { ENV_VARS } from '../constants/index.js';
+import { deriveKeyInfo, ensureKeyImported } from './ipns-key-manager.js';
+import { ENV_VARS, DEFAULTS } from '../constants/index.js';
 
 const logger = createLogger('IPFSSecretsStorage');
 
@@ -25,6 +26,7 @@ export interface IPFSSecretsMetadata {
   git_repo?: string;
   git_branch?: string;
   cid: string;
+  ipns_name?: string;
   timestamp: string;
   keys_count: number;
   encrypted: boolean;
@@ -148,6 +150,29 @@ export class IPFSSecretsStorage {
         }
       }
 
+      // Publish to IPNS if we uploaded to the network
+      if (uploadedToNetwork && realCid && encryptionKey) {
+        try {
+          const repoName = gitRepo || DEFAULTS.DEFAULT_ENVIRONMENT;
+          const env = environment || DEFAULTS.DEFAULT_ENVIRONMENT;
+          const keyInfo = deriveKeyInfo(encryptionKey, repoName, env);
+          const ipnsName = await ensureKeyImported(ipfsSync.getApiUrl(), keyInfo);
+
+          if (ipnsName) {
+            const publishedName = await ipfsSync.publishToIPNS(realCid, keyInfo.keyName);
+            if (publishedName) {
+              metadata.ipns_name = publishedName;
+              this.metadata[this.getMetadataKey(gitRepo, environment)] = metadata;
+              await this.saveMetadata();
+              logger.info(`   🔗 Published to IPNS: ${publishedName}`);
+            }
+          }
+        } catch (error) {
+          const err = error as Error;
+          logger.warn(`   ⚠️  IPNS publish failed (non-fatal): ${err.message}`);
+        }
+      }
+
       if (!uploadedToNetwork) {
         logger.warn(`   📁 Secrets cached locally only (no network sync)`);
         logger.warn(`   💡 Start IPFS daemon for network sync: lsh ipfs start`);
@@ -178,7 +203,43 @@ export class IPFSSecretsStorage {
         ? (environment ? `${gitRepo}_${environment}` : gitRepo)
         : (environment || 'default');
 
-      // If no local metadata, check IPFS sync history
+      // If no local metadata, try IPNS resolution first
+      if (!metadata && encryptionKey) {
+        try {
+          const ipfsSync = getIPFSSync();
+          if (await ipfsSync.checkDaemon()) {
+            const repoName = gitRepo || DEFAULTS.DEFAULT_ENVIRONMENT;
+            const env = environment || DEFAULTS.DEFAULT_ENVIRONMENT;
+            const keyInfo = deriveKeyInfo(encryptionKey, repoName, env);
+            const ipnsName = await ensureKeyImported(ipfsSync.getApiUrl(), keyInfo);
+
+            if (ipnsName) {
+              logger.info(`   🔍 Resolving via IPNS: ${ipnsName.substring(0, 20)}...`);
+              const resolvedCid = await ipfsSync.resolveIPNS(ipnsName);
+
+              if (resolvedCid) {
+                logger.info(`   ✅ IPNS resolved to CID: ${resolvedCid}`);
+                metadata = {
+                  environment,
+                  git_repo: gitRepo,
+                  cid: resolvedCid,
+                  ipns_name: ipnsName,
+                  timestamp: new Date().toISOString(),
+                  keys_count: 0,
+                  encrypted: true,
+                };
+                this.metadata[metadataKey] = metadata;
+                await this.saveMetadata();
+              }
+            }
+          }
+        } catch (error) {
+          const err = error as Error;
+          logger.debug(`   IPNS resolution failed: ${err.message}`);
+        }
+      }
+
+      // If still no metadata, check IPFS sync history
       if (!metadata && gitRepo) {
         try {
           const ipfsSync = getIPFSSync();

--- a/src/lib/ipfs-sync.ts
+++ b/src/lib/ipfs-sync.ts
@@ -25,6 +25,7 @@ export interface SyncHistoryEntry {
   size: number;
   environment?: string;
   gitRepo?: string;
+  ipnsName?: string;
 }
 
 export interface IPFSAddResponse {
@@ -393,6 +394,74 @@ export class IPFSSync {
    */
   getGatewayUrls(cid: string): string[] {
     return this.GATEWAYS.map(template => template.replace('{cid}', cid));
+  }
+
+  /**
+   * Get the Kubo API URL
+   */
+  getApiUrl(): string {
+    return this.LOCAL_IPFS_API;
+  }
+
+  /**
+   * Publish a CID to IPNS under the given key name.
+   * The key must already be imported into Kubo.
+   * Returns the IPNS name on success, null on failure.
+   */
+  async publishToIPNS(cid: string, keyName: string): Promise<string | null> {
+    try {
+      const response = await fetch(
+        `${this.LOCAL_IPFS_API}/name/publish?arg=${cid}&key=${encodeURIComponent(keyName)}&lifetime=87600h&resolve=false`,
+        {
+          method: 'POST',
+          signal: AbortSignal.timeout(30000),
+        }
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        logger.warn(`IPNS publish failed: ${errorText}`);
+        return null;
+      }
+
+      const data = await response.json() as { Name: string; Value: string };
+      logger.info(`📡 IPNS published: ${data.Name} → ${data.Value}`);
+      return data.Name;
+    } catch (error) {
+      const err = error as Error;
+      logger.debug(`IPNS publish error: ${err.message}`);
+      return null;
+    }
+  }
+
+  /**
+   * Resolve an IPNS name to its current CID.
+   * Returns the CID (without /ipfs/ prefix) on success, null on failure/timeout.
+   */
+  async resolveIPNS(ipnsName: string): Promise<string | null> {
+    try {
+      const response = await fetch(
+        `${this.LOCAL_IPFS_API}/name/resolve?arg=${encodeURIComponent(ipnsName)}&nocache=true`,
+        {
+          method: 'POST',
+          signal: AbortSignal.timeout(30000),
+        }
+      );
+
+      if (!response.ok) {
+        return null;
+      }
+
+      const data = await response.json() as { Path: string };
+      // Strip /ipfs/ prefix to get the raw CID
+      const resolvedCid = data.Path.replace(/^\/ipfs\//, '');
+      logger.info(`📡 IPNS resolved: ${ipnsName} → ${resolvedCid}`);
+      return resolvedCid;
+    } catch (error) {
+      const err = error as Error;
+      logger.debug(`IPNS resolve error: ${err.message}`);
+      return null;
+    }
   }
 }
 

--- a/src/lib/ipns-key-manager.ts
+++ b/src/lib/ipns-key-manager.ts
@@ -1,0 +1,112 @@
+/**
+ * IPNS Key Manager
+ *
+ * Deterministic IPNS key derivation from LSH_SECRETS_KEY.
+ * Same key + repo + env always produces the same IPNS name,
+ * so teammates only need to share the encryption key.
+ */
+
+import * as crypto from 'crypto';
+import { DEFAULTS } from '../constants/config.js';
+import { createLogger } from './logger.js';
+
+const logger = createLogger('IPNSKeyManager');
+
+export interface IPNSKeyInfo {
+  keyName: string;   // Kubo keystore name, e.g. "lsh-3c3080bd2a8c73b0"
+  seed: Buffer;      // 32-byte ed25519 seed
+}
+
+// PKCS8 DER prefix for ed25519 private keys (RFC 8410)
+// This wraps a raw 32-byte seed into a valid PKCS8 structure.
+const ED25519_PKCS8_PREFIX = Buffer.from(
+  '302e020100300506032b657004220420',
+  'hex'
+);
+
+/**
+ * Derive deterministic IPNS key info from secrets key + repo + env.
+ * Same inputs always produce the same key.
+ */
+export function deriveKeyInfo(
+  secretsKey: string,
+  repoName: string,
+  environment: string
+): IPNSKeyInfo {
+  const context = `${DEFAULTS.IPNS_KEY_DERIVATION_CONTEXT}:${repoName}:${environment}`;
+  const seed = crypto.createHmac('sha256', secretsKey)
+    .update(context)
+    .digest();
+
+  const keyName = DEFAULTS.IPNS_KEY_PREFIX +
+    crypto.createHash('sha256').update(seed).digest('hex').substring(0, 16);
+
+  return { keyName, seed };
+}
+
+/**
+ * Build a PEM-encoded PKCS8 ed25519 private key from a 32-byte seed.
+ * This is the format Kubo's /key/import accepts with format=pem-pkcs8-cleartext.
+ */
+export function buildPemFromSeed(seed: Buffer): string {
+  const pkcs8Der = Buffer.concat([ED25519_PKCS8_PREFIX, seed]);
+  const b64 = pkcs8Der.toString('base64');
+  const lines = b64.match(/.{1,64}/g) || [b64];
+  return `-----BEGIN PRIVATE KEY-----\n${lines.join('\n')}\n-----END PRIVATE KEY-----\n`;
+}
+
+/**
+ * Ensure the derived key is imported into the local Kubo node.
+ * Idempotent: checks /key/list first, only imports if missing.
+ * Returns the IPNS name (peer ID) on success, null on failure.
+ */
+export async function ensureKeyImported(
+  kuboApiUrl: string,
+  keyInfo: IPNSKeyInfo
+): Promise<string | null> {
+  try {
+    // Check if key already exists
+    const listResponse = await fetch(`${kuboApiUrl}/key/list`, {
+      method: 'POST',
+      signal: AbortSignal.timeout(5000),
+    });
+
+    if (listResponse.ok) {
+      const listData = await listResponse.json() as { Keys: Array<{ Name: string; Id: string }> };
+      const existing = listData.Keys?.find(k => k.Name === keyInfo.keyName);
+      if (existing) {
+        logger.debug(`IPNS key "${keyInfo.keyName}" already imported: ${existing.Id}`);
+        return existing.Id;
+      }
+    }
+
+    // Import the key
+    const pem = buildPemFromSeed(keyInfo.seed);
+    const formData = new FormData();
+    const blob = new Blob([pem], { type: 'application/x-pem-file' });
+    formData.append('file', blob, 'key.pem');
+
+    const importResponse = await fetch(
+      `${kuboApiUrl}/key/import?arg=${encodeURIComponent(keyInfo.keyName)}&format=pem-pkcs8-cleartext`,
+      {
+        method: 'POST',
+        body: formData,
+        signal: AbortSignal.timeout(5000),
+      }
+    );
+
+    if (!importResponse.ok) {
+      const errorText = await importResponse.text();
+      logger.warn(`Failed to import IPNS key: ${errorText}`);
+      return null;
+    }
+
+    const importData = await importResponse.json() as { Name: string; Id: string };
+    logger.info(`Imported IPNS key "${importData.Name}": ${importData.Id}`);
+    return importData.Id;
+  } catch (error) {
+    const err = error as Error;
+    logger.debug(`IPNS key import failed: ${err.message}`);
+    return null;
+  }
+}

--- a/types/constants/config.d.ts
+++ b/types/constants/config.d.ts
@@ -107,4 +107,9 @@ export declare const DEFAULTS: {
     readonly DEFAULT_SHELL_UNIX: "/bin/sh";
     readonly DEFAULT_SHELL_WIN: "cmd.exe";
     readonly DEFAULT_EDITOR: "vi";
+    readonly DEFAULT_ENVIRONMENT: "default";
+    readonly IPNS_PUBLISH_LIFETIME: "87600h";
+    readonly IPNS_RESOLVE_TIMEOUT_MS: 30000;
+    readonly IPNS_KEY_PREFIX: "lsh-";
+    readonly IPNS_KEY_DERIVATION_CONTEXT: "lsh-ipns-v1";
 };

--- a/types/lib/ipfs-secrets-storage.d.ts
+++ b/types/lib/ipfs-secrets-storage.d.ts
@@ -12,6 +12,7 @@ export interface IPFSSecretsMetadata {
     git_repo?: string;
     git_branch?: string;
     cid: string;
+    ipns_name?: string;
     timestamp: string;
     keys_count: number;
     encrypted: boolean;

--- a/types/lib/ipfs-sync.d.ts
+++ b/types/lib/ipfs-sync.d.ts
@@ -16,6 +16,7 @@ export interface SyncHistoryEntry {
     size: number;
     environment?: string;
     gitRepo?: string;
+    ipnsName?: string;
 }
 export interface IPFSAddResponse {
     Name: string;
@@ -94,6 +95,21 @@ export declare class IPFSSync {
      * Get public gateway URLs for a CID
      */
     getGatewayUrls(cid: string): string[];
+    /**
+     * Get the Kubo API URL
+     */
+    getApiUrl(): string;
+    /**
+     * Publish a CID to IPNS under the given key name.
+     * The key must already be imported into Kubo.
+     * Returns the IPNS name on success, null on failure.
+     */
+    publishToIPNS(cid: string, keyName: string): Promise<string | null>;
+    /**
+     * Resolve an IPNS name to its current CID.
+     * Returns the CID (without /ipfs/ prefix) on success, null on failure/timeout.
+     */
+    resolveIPNS(ipnsName: string): Promise<string | null>;
 }
 /**
  * Get singleton IPFSSync instance

--- a/types/lib/ipns-key-manager.d.ts
+++ b/types/lib/ipns-key-manager.d.ts
@@ -1,0 +1,27 @@
+/**
+ * IPNS Key Manager
+ *
+ * Deterministic IPNS key derivation from LSH_SECRETS_KEY.
+ * Same key + repo + env always produces the same IPNS name,
+ * so teammates only need to share the encryption key.
+ */
+export interface IPNSKeyInfo {
+    keyName: string;
+    seed: Buffer;
+}
+/**
+ * Derive deterministic IPNS key info from secrets key + repo + env.
+ * Same inputs always produce the same key.
+ */
+export declare function deriveKeyInfo(secretsKey: string, repoName: string, environment: string): IPNSKeyInfo;
+/**
+ * Build a PEM-encoded PKCS8 ed25519 private key from a 32-byte seed.
+ * This is the format Kubo's /key/import accepts with format=pem-pkcs8-cleartext.
+ */
+export declare function buildPemFromSeed(seed: Buffer): string;
+/**
+ * Ensure the derived key is imported into the local Kubo node.
+ * Idempotent: checks /key/list first, only imports if missing.
+ * Returns the IPNS name (peer ID) on success, null on failure.
+ */
+export declare function ensureKeyImported(kuboApiUrl: string, keyInfo: IPNSKeyInfo): Promise<string | null>;


### PR DESCRIPTION
## Summary
- Derive deterministic ed25519 keypair from `LSH_SECRETS_KEY + repo + env` for IPNS publishing
- Teammates only need to share `LSH_SECRETS_KEY` — no CID sharing required
- `lsh sync pull` (no args) auto-resolves latest secrets via IPNS
- `lsh sync pull <cid>` still works for pinning to specific versions
- IPNS info shown in `lsh ipfs status` when key is configured
- Graceful degradation: IPNS silently skipped when daemon is down or key is unset

## Design
Same key + same repo + same env = same IPNS name. Like git: IPNS = branch pointer (latest), CID = commit hash (immutable).

## Test plan
- [x] `npm run build` — compiles cleanly
- [x] 10 unit tests for key derivation determinism, isolation, and PEM validity
- [x] 105 total tests pass across core suites
- [x] No new lint errors
- [x] `lsh sync pull --help` shows optional `[cid]` with `--env` option
- [x] `lsh ipfs status` gracefully degrades without `LSH_SECRETS_KEY`
- [ ] CI passes on GitHub

## Summary by Sourcery

Introduce deterministic IPNS-based auto-sync for secrets, enabling repo/environment-specific IPNS names derived from the shared secrets key and integrating them into sync and IPFS workflows.

New Features:
- Add deterministic IPNS key derivation from LSH_SECRETS_KEY, repo, and environment via a new IPNS key manager module.
- Enable automatic publishing of pushed secrets CIDs to IPNS and resolution of latest secrets via IPNS when pulling without a CID.
- Expose IPNS publish and resolve capabilities on the IPFS sync client and surface IPNS information in the `lsh ipfs status` command.
- Support `lsh sync pull [cid]` with optional environment selection, defaulting to IPNS-based resolution when CID is omitted.

Enhancements:
- Store and expose IPNS names in IPFS sync history and secrets metadata for better traceability of published records.
- Update CLI messages and quick actions to guide users toward IPNS-based `lsh sync push`/`pull` flows instead of sharing raw CIDs.
- Add IPNS-related defaults to configuration, including default environment, key prefix, derivation context, and timeouts.
- Tighten typing in IPFS client manager polling logic.

Build:
- Bump package version from 3.1.26 to 3.2.0 to reflect the new IPNS auto-sync capability.

Tests:
- Add unit test coverage for the IPNS key manager, including deterministic key derivation and PEM generation.