### PR TITLE
feat(sync): add --repo flag for cross-repo IPNS pull

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lsh-framework",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lsh-framework",
-      "version": "3.2.4",
+      "version": "3.2.5",
       "license": "MIT",
       "dependencies": {
         "@supabase/supabase-js": "^2.57.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lsh-framework",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "description": "Simple, cross-platform encrypted secrets manager with automatic sync, IPFS audit logs, and multi-environment support. Just run lsh sync and start managing your secrets.",
   "main": "dist/app.js",
   "bin": {

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -384,6 +384,7 @@ export function registerSyncCommands(program: Command): void {
     .description('⬇️  Pull secrets from IPFS (auto-resolves via IPNS if no CID given)')
     .option('-o, --output <path>', 'Output file path', '.env')
     .option('-e, --env <name>', 'Environment name', '')
+    .option('-r, --repo <name>', 'Source repo name for IPNS resolution (overrides auto-detected repo)')
     .option('--force', 'Overwrite existing file without backup')
     .action(async (cid, options) => {
       const spinner = ora(cid ? 'Downloading from IPFS...' : 'Resolving latest secrets via IPNS...').start();
@@ -421,7 +422,7 @@ export function registerSyncCommands(program: Command): void {
           }
 
           const gitInfo = getGitRepoInfo();
-          const repoName = gitInfo?.repoName || DEFAULTS.DEFAULT_ENVIRONMENT;
+          const repoName = options.repo || gitInfo?.repoName || DEFAULTS.DEFAULT_ENVIRONMENT;
           const environment = options.env || DEFAULTS.DEFAULT_ENVIRONMENT;
           const keyInfo = deriveKeyInfo(ipnsKey, repoName, environment);
           const ipnsName = await ensureKeyImported(ipfsSync.getApiUrl(), keyInfo);


### PR DESCRIPTION
## Summary
- Adds `-r, --repo <name>` flag to `lsh sync pull` to override the auto-detected repo name during IPNS resolution
- Fixes cross-repo secret sharing where a differently-named repo can't resolve the source repo's IPNS name

## Problem
IPNS key derivation uses `HMAC(secretsKey, "lsh-ipns-v1:<repoName>:<env>")`. When pulling secrets into a repo with a different name (e.g., `conduit-test` pulling `conduit`'s secrets), IPNS resolution fails because the derived key name differs.

## Solution
`lsh sync pull --repo conduit` overrides the repo name context so the correct IPNS name is derived.

## Test plan
- [x] E2E: push from `~/repos/conduit`, import key into `~/repos/conduit-test`
- [x] `lsh sync pull` without `--repo` → fails (different IPNS name)
- [x] `lsh sync pull --repo conduit` → resolves correct IPNS, pulls all 9 secrets
- [x] Build passes

## Summary by Sourcery

Add support for overriding the source repository name when pulling secrets via IPNS to enable cross-repo sync and bump the package version.

New Features:
- Add a -r, --repo flag to lsh sync pull to specify the source repository name for IPNS resolution.

Enhancements:
- Allow IPNS key derivation during sync pull to use an explicitly provided repo name before falling back to the detected git repo name or default environment.

Build:
- Bump package version from 3.2.4 to 3.2.5.