### PR TITLE
chore(deps): remove unused uuid dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,8 +26,7 @@
         "ora": "^9.0.0",
         "pg": "^8.16.3",
         "proper-lockfile": "^4.1.2",
-        "smol-toml": "^1.3.1",
-        "uuid": "^13.0.0"
+        "smol-toml": "^1.3.1"
       },
       "bin": {
         "lsh": "dist/cli.js"
@@ -9369,19 +9368,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -80,8 +80,7 @@
     "ora": "^9.0.0",
     "pg": "^8.16.3",
     "proper-lockfile": "^4.1.2",
-    "smol-toml": "^1.3.1",
-    "uuid": "^13.0.0"
+    "smol-toml": "^1.3.1"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",


### PR DESCRIPTION
## Summary

`uuid` was a **dead direct dependency** — declared in `package.json` (`^13.0.0`) but imported nowhere in the codebase. The only `uuid` references are Postgres-side `gen_random_uuid()` in schema SQL and an unrelated local `Rules.uuid()` validator, neither of which use the npm package.

Removing the dead dependency instead of merging dependabot's 13→14 major bump (#175, now closed). No other package depends on `uuid`.

## Before / After

**Before**
```mermaid
graph LR
  pkg[package.json deps] --> uuid["uuid ^13.0.0"]
  uuid -.->|imported by| nothing["(no source imports)"]
  src[src/**] -->|gen_random_uuid SQL| pg[(Postgres)]
  src -->|Rules.uuid validator| local[local validation-rules.ts]
```

**After**
```mermaid
graph LR
  pkg[package.json deps] -.->|uuid removed| gone["∅"]
  src[src/**] -->|gen_random_uuid SQL| pg[(Postgres)]
  src -->|Rules.uuid validator| local[local validation-rules.ts]
```

## Verification
- `npx tsc` — 0 errors
- `npm run lint` — 0 errors
- `npm ls uuid` — no remaining dependents

Closes the need for #175.

## Summary by Sourcery

Chores:
- Remove the unused `uuid` package from runtime dependencies to clean up the dependency graph.