### PR TITLE
chore: declare @eslint/js dep + migrate tsconfig to nodenext

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "lsh": "dist/cli.js"
       },
       "devDependencies": {
+        "@eslint/js": "^9.39.4",
         "@types/bcrypt": "^5.0.2",
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
@@ -701,9 +702,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.2",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
-      "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3846,6 +3847,19 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/@eslint/js": {
+      "version": "9.39.2",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
+      "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/eslint/node_modules/ansi-styles": {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "smol-toml": "^1.3.1"
   },
   "devDependencies": {
+    "@eslint/js": "^9.39.4",
     "@types/bcrypt": "^5.0.2",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,11 +13,11 @@
     "alwaysStrict": true,               // ✓ Phase 3: 0 errors
     // "noImplicitAny": true,           // TODO: ~150+ errors - future work
     "sourceMap": false,
-    "module": "ES2022",
+    "module": "nodenext",
     "esModuleInterop": true, // Enables emit interoperability between CommonJS and ES Modules
     "skipLibCheck": true, // Skip type checking of declaration files
     "forceConsistentCasingInFileNames": true, // Disallow inconsistently-cased references to the same file
-    "moduleResolution": "Node",
+    "moduleResolution": "nodenext",
     "jsx": "react",
     "declaration": true,
     "declarationDir": "./types",


### PR DESCRIPTION
## Summary

Fixes two latent config issues surfaced during dependabot dependency triage. Foundational — unblocks the eslint 10 bump in #172.

1. **`@eslint/js` undeclared** — imported by `eslint.config.js` but never in `package.json`. eslint 9 resolved it transitively; eslint 10 does not, so linting would break on the eslint bump. Now declared explicitly (`^9.39.4`).
2. **Deprecated `moduleResolution: "Node"` (node10)** — deprecated in TS 6, removed in TS 7. Migrated `module` + `moduleResolution` to `nodenext`. Codebase already uses explicit `.js` import extensions, so build is clean.

## Before / After

**Before**
```mermaid
graph TD
  cfg[eslint.config.js] -->|import| ejs["@eslint/js (undeclared)"]
  ejs -.->|transitive via eslint 9 only| risk["breaks on eslint 10"]
  tsc[tsconfig] --> nres["moduleResolution: Node / node10"]
  nres -.->|deprecated TS6, gone TS7| risk2["breaks on TS7"]
```

**After**
```mermaid
graph TD
  cfg[eslint.config.js] -->|import| ejs["@eslint/js ^9.39.4 (declared)"]
  pkg[package.json devDeps] --> ejs
  tsc[tsconfig] --> nres["module + moduleResolution: nodenext"]
  nres -->|forward-compatible| ok["builds clean, TS7-ready"]
```

## Verification
- `npx tsc` — 0 errors (nodenext)
- `npm run lint` — 0 errors

## Summary by Sourcery

Update TypeScript and ESLint configuration to be compatible with newer tooling versions.

Enhancements:
- Switch TypeScript module and moduleResolution settings to nodenext for forward-compatible Node ESM support.
- Declare @eslint/js as an explicit devDependency to match its usage in the ESLint config.