### PR TITLE
chore(release): 3.4.0 — dependency modernization

### DIFF
--- a/docs/releases/3.4.0.md
+++ b/docs/releases/3.4.0.md
@@ -1,0 +1,63 @@
+# Release 3.4.0
+
+**Date:** 2026-06-01
+
+Dependency modernization release. Brings the toolchain and runtime dependencies up to their current major versions, with the compatibility fixes required to build, lint, and test cleanly. No changes to LSH's public CLI or API surface.
+
+## Highlights
+
+- **Express 4 → 5** (`express ^5.2.1`, `@types/express ^5`)
+- **TypeScript 5 → 6** (`typescript ^6.0.3`)
+- **ESLint 9 → 10** (`eslint ^10.4.1`, `@eslint/js ^10.0.1`, `@typescript-eslint/* ^8.60`)
+- **Jest 29 → 30** (`jest ^30.4.2`)
+- **inquirer 9 → 14**, **commander 14 → 15** (ESM), `@types/node 20 → 25`
+- Removed the unused `uuid` dependency.
+
+## Compatibility fixes
+
+| Area | Change |
+|------|--------|
+| Express 5 params | `@types/express` v5 widened `ParamsDictionary` values to `string \| string[]`. `AuthenticatedRequest` now narrows `params` to `Record<string, string>` (named route params are always strings at runtime) — one override clears all 21 `saas-api-routes.ts` type errors. |
+| ESLint 10 API | Custom rule `eslint-plugin-lsh/no-hardcoded-strings` switched from the removed `context.getFilename()` to `context.filename`. |
+| ESLint 10 rule | New recommended `preserve-caught-error`: attached `{ cause }` to 13 errors re-thrown inside catch blocks (real error-chain improvement). |
+| `@eslint/js` | Now declared explicitly — eslint 9 resolved it transitively, eslint 10 does not. |
+| TypeScript 6 | `tsconfig` migrated `moduleResolution` from deprecated `Node` (node10) to `nodenext`; removed before TS 7. |
+| Jest 30 / TS 6 | `jest.config.js`'s inline ts-jest tsconfig switched `moduleResolution` `node` → `bundler` and set `rootDir: '.'` (node10 + undefined rootDir became hard errors under TS 6). |
+
+## Verification
+
+- `tsc` — 0 errors
+- `eslint` — 0 errors
+- `jest` — 1568 passed / 28 skipped / 0 failed
+- Express 5 route-registration smoke test — passes (no path-to-regexp v8 breakage)
+- inquirer 14 default-export `.prompt()` — runtime-verified
+
+## Before / After
+
+**Before** — dependency baseline
+```mermaid
+graph LR
+  lsh[lsh 3.3.0] --> e4[express 4.22]
+  lsh --> ts5[typescript 5]
+  lsh --> es9[eslint 9]
+  lsh --> j29[jest 29]
+  lsh --> u[uuid 13 unused]
+  lsh -.->|@eslint/js undeclared| risk[breaks on eslint 10]
+  ts5 -.->|moduleResolution node10| risk2[breaks on TS 7]
+```
+
+**After** — modernized
+```mermaid
+graph LR
+  lsh[lsh 3.4.0] --> e5[express 5.2]
+  lsh --> ts6[typescript 6]
+  lsh --> es10[eslint 10]
+  lsh --> j30[jest 30]
+  lsh --> ejs[@eslint/js 10 declared]
+  ts6 --> nn[moduleResolution nodenext]
+  e5 --> ovr[AuthenticatedRequest.params narrowed]
+```
+
+## PRs
+
+#177, #178, #180, #181, #172, #173 (plus GitHub Action bumps #164–#168).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lsh-framework",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lsh-framework",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "license": "MIT",
       "dependencies": {
         "@supabase/supabase-js": "^2.57.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lsh-framework",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Simple, cross-platform encrypted secrets manager with automatic sync, IPFS audit logs, and multi-environment support. Just run lsh sync and start managing your secrets.",
   "main": "dist/app.js",
   "bin": {


### PR DESCRIPTION
Version bump to **3.4.0** capping the dependency modernization (Express 5, TypeScript 6, ESLint 10, Jest 30, inquirer 14, commander 15; uuid removed).

Full notes + before/after diagram: `docs/releases/3.4.0.md`.

No public CLI/API change. Verified: tsc 0 · eslint 0 · jest 1568 passed.

## Summary by Sourcery

Finalize the 3.4.0 release and document the dependency modernization changes.

Enhancements:
- Bump the package version to 3.4.0 to reflect the completed dependency modernization cycle.

Documentation:
- Add release notes for version 3.4.0 describing the dependency upgrades, compatibility adjustments, and verification status.