### PR TITLE
ci(publish): npm trusted publishing (OIDC), drop expired NPM_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,10 @@ jobs:
         node-version: '20.18.0'
         registry-url: 'https://registry.npmjs.org'
 
+    # Trusted Publishing (OIDC) requires npm >= 11.5.1; Node 20.18 ships npm 10.x.
+    - name: Upgrade npm for trusted publishing
+      run: npm install -g npm@latest
+
     - name: Install dependencies
       run: npm ci
 
@@ -58,11 +62,12 @@ jobs:
           echo "Version ${{ steps.package.outputs.version }} does not exist on npm - will publish"
         fi
 
+    # Trusted Publishing: npm authenticates via OIDC (id-token: write) against the
+    # trusted publisher configured on npmjs for this repo+workflow+environment.
+    # No NPM_TOKEN — the CLI exchanges the OIDC token for a short-lived publish token.
     - name: Publish to npm
       if: steps.npm_check.outputs.exists == 'false'
       run: npm publish --provenance --access public
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     - name: Skip publish (already exists)
       if: steps.npm_check.outputs.exists == 'true'


### PR DESCRIPTION
## Why

The publish workflow signed provenance via OIDC but authenticated the actual `PUT` with `secrets.NPM_TOKEN` — which expired around Jan 21. Every release since **3.2.5** failed (masked `404`): v3.2.6 and v3.4.0 both never reached npm.

## What

Switch to real npm **Trusted Publishing**:
- Upgrade npm in-job (`npm@latest`) — OIDC trusted publishing needs **npm ≥ 11.5.1**; Node 20.18 ships npm 10.x.
- Drop `NODE_AUTH_TOKEN` — the CLI now exchanges the workflow's OIDC token (`id-token: write`) for a short-lived publish token, authorized by the trusted publisher configured on npmjs.

## One-time npmjs setup (required before this works)

Package `lsh-framework` → Settings → **Trusted Publisher** → GitHub Actions:
| Field | Value |
|---|---|
| Org/user | `gwicho38` |
| Repository | `lsh` |
| Workflow | `publish.yml` |
| Environment | `npm-publish` |

After merge + that setup, re-tagging `v3.4.0` publishes with no token and no 2FA.

## Summary by Sourcery

Switch the npm publish GitHub Actions workflow to use npm Trusted Publishing via OIDC instead of an NPM_TOKEN secret.

CI:
- Upgrade npm in the publish workflow job to a version that supports Trusted Publishing with provenance.
- Remove reliance on the NODE_AUTH_TOKEN secret so publishing authenticates via the workflow's OIDC token and configured trusted publisher.