### PR TITLE
fix(ci): drop --provenance for self-hosted npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,9 +65,14 @@ jobs:
     # Trusted Publishing: npm authenticates via OIDC (id-token: write) against the
     # trusted publisher configured on npmjs for this repo+workflow+environment.
     # No NPM_TOKEN — the CLI exchanges the OIDC token for a short-lived publish token.
+    #
+    # NOTE: --provenance is intentionally omitted. This workflow runs on a self-hosted
+    # runner, and npm rejects provenance from self-hosted runners ("Only github-hosted
+    # runners are supported when publishing with provenance", error E422). OIDC trusted
+    # publishing itself works on self-hosted; only sigstore provenance attestation does not.
     - name: Publish to npm
       if: steps.npm_check.outputs.exists == 'false'
-      run: npm publish --provenance --access public
+      run: npm publish --access public
 
     - name: Skip publish (already exists)
       if: steps.npm_check.outputs.exists == 'true'


### PR DESCRIPTION
## Problem
With the test gate fixed (3.4.1), the publish reached `npm publish` and npm rejected it:

\`\`\`
npm error code E422
npm error 422 — Error verifying sigstore provenance bundle: Unsupported GitHub Actions
runner environment: "self-hosted". Only "github-hosted" runners are supported when
publishing with provenance.
\`\`\`

`publish.yml` runs on `[self-hosted, linux, x64]`. **npm `--provenance` only works on github-hosted runners.**

## Fix
Drop `--provenance` from `npm publish`. OIDC trusted publishing (no NPM_TOKEN) still works on self-hosted; only the sigstore provenance attestation is unsupported there. Keeps the repo on its self-hosted runner per the act-first policy.

## Before / After
**Before:** `npm publish --provenance --access public` → E422 on self-hosted → never publishes.
**After:** `npm publish --access public` → OIDC auth succeeds on self-hosted → publishes.

Trade-off: loses sigstore provenance attestation (added in #183). Acceptable to keep self-hosted; revisit by moving only the publish job to ubuntu-latest if provenance is desired later.

## Summary by Sourcery

CI:
- Remove the --provenance flag from the npm publish step in the GitHub Actions workflow to avoid failures on self-hosted runners and document the limitation in comments.