### PR TITLE
fix(self): scope self-update CI check to build workflow

### DIFF
--- a/__tests__/self-ci-status.test.ts
+++ b/__tests__/self-ci-status.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Regression tests for `lsh self update` build-status evaluation.
+ *
+ * Bug: checkCIStatus queried the most recent completed run of ANY workflow, so a
+ * flaky security scan (e.g. Codacy timing out downloading codeql-action) made
+ * `lsh self update` report "build failing" even though the build was fine. Fix
+ * scopes the query to node.js.yml and treats only a real `failure` as blocking.
+ */
+import { describe, it, expect } from '@jest/globals';
+import { evaluateBuildRuns } from '../src/commands/self.js';
+
+const run = (status: string, conclusion: string | null, url = 'https://x/1') => ({
+  head_branch: 'main',
+  status,
+  conclusion,
+  html_url: url,
+} as any);
+
+describe('evaluateBuildRuns', () => {
+  it('blocks only on a real failure of the latest completed run', () => {
+    const r = evaluateBuildRuns([run('completed', 'failure', 'https://x/fail')]);
+    expect(r.passing).toBe(false);
+    expect(r.url).toBe('https://x/fail');
+  });
+
+  it('treats cancelled as passing (concurrency cancels are infra noise, not a failing build)', () => {
+    expect(evaluateBuildRuns([run('completed', 'cancelled')]).passing).toBe(true);
+  });
+
+  it('treats success as passing', () => {
+    expect(evaluateBuildRuns([run('completed', 'success')]).passing).toBe(true);
+  });
+
+  it('treats skipped / null conclusion as passing', () => {
+    expect(evaluateBuildRuns([run('completed', 'skipped')]).passing).toBe(true);
+    expect(evaluateBuildRuns([run('completed', null)]).passing).toBe(true);
+  });
+
+  it('ignores in-progress/queued runs and uses the most recent completed one', () => {
+    const runs = [
+      run('in_progress', null, 'https://x/running'),
+      run('completed', 'failure', 'https://x/fail'),
+    ];
+    const r = evaluateBuildRuns(runs);
+    expect(r.passing).toBe(false);
+    expect(r.url).toBe('https://x/fail');
+  });
+
+  it('does not block when there are no completed runs', () => {
+    expect(evaluateBuildRuns([run('queued', null)]).passing).toBe(true);
+    expect(evaluateBuildRuns([]).passing).toBe(true);
+  });
+});

--- a/docs/releases/3.5.1.md
+++ b/docs/releases/3.5.1.md
@@ -1,0 +1,44 @@
+# 3.5.1 — Fix false "build failing" in `lsh self update`
+
+Patch release.
+
+## Fix
+
+`lsh self update` reported the **build as failing for the latest version** when it
+wasn't. `checkCIStatus` queried the most recent completed run of **any** workflow
+(`/actions/runs?per_page=5`) and treated a non-`success` conclusion as a failing build.
+So a flaky **security scan** — e.g. Codacy timing out downloading `codeql-action`
+(`HttpClient.Timeout of 100 seconds`) — read as "build failing", even though the actual
+build (`Node.js CI`) was fine (just queued on the self-hosted runner, or cancelled by
+concurrency).
+
+Two changes:
+- **Scope to the build workflow**: query `actions/workflows/node.js.yml/runs?branch=main`
+  instead of all workflows, so security-scan results can't be mistaken for the build.
+- **Only block on a real failure**: `cancelled` / `skipped` / `null` conclusions are infra
+  noise (the build is frequently cancelled by concurrency on the self-hosted runner) and no
+  longer report as failing. Logic extracted to a pure, unit-tested `evaluateBuildRuns()`.
+
+## Before / After
+
+```mermaid
+flowchart TD
+    subgraph Before
+      A1["self update"] --> B1["latest completed run of ANY workflow"]
+      B1 --> C1{"conclusion == success?"}
+      C1 -->|"Codacy timeout = failure"| D1["❌ reports build failing"]
+    end
+    subgraph After
+      A2["self update"] --> B2["latest completed run of node.js.yml on main"]
+      B2 --> C2{"conclusion == failure?"}
+      C2 -->|"cancelled/skipped/success"| D2["✅ not blocking"]
+      C2 -->|"failure"| E2["❌ real build failure"]
+    end
+```
+
+## Verification
+
+- `npm run typecheck` / `npm run build` — 0 errors
+- `npm run lint` — 0 errors
+- New `__tests__/self-ci-status.test.ts` — 6/6 pass (failure blocks; cancelled/skipped/success/empty don't)
+- Full suite — 998 passed, 0 failed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lsh-framework",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lsh-framework",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "license": "MIT",
       "dependencies": {
         "@supabase/supabase-js": "^2.57.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lsh-framework",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Simple, cross-platform encrypted secrets manager with automatic sync, IPFS audit logs, and multi-environment support. Just run lsh sync and start managing your secrets.",
   "main": "dist/cli.js",
   "bin": {

--- a/src/commands/self.ts
+++ b/src/commands/self.ts
@@ -120,6 +120,25 @@ async function fetchLatestVersion(): Promise<{ version: string; publishedAt?: st
 }
 
 /**
+ * Decide build status from the build workflow's runs (pure, unit-testable).
+ *
+ * Only a real `failure` on the most recent COMPLETED run blocks an update.
+ * `cancelled` / `skipped` / `null` are infra noise — the build is frequently
+ * cancelled by concurrency on the self-hosted runner — and must NOT be reported
+ * as a failing build. No completed runs → treat as passing (don't block).
+ */
+export function evaluateBuildRuns(
+  runs: GitHubWorkflowRun[],
+): { passing: boolean; url?: string } {
+  const completed = (runs || []).filter((run) => run.status === 'completed');
+  if (completed.length === 0) {
+    return { passing: true };
+  }
+  const latest = completed[0];
+  return { passing: latest.conclusion !== 'failure', url: latest.html_url };
+}
+
+/**
  * Check GitHub Actions CI status for a specific version tag
  */
 async function checkCIStatus(_version: string): Promise<{ passing: boolean; url?: string }> {
@@ -127,7 +146,9 @@ async function checkCIStatus(_version: string): Promise<{ passing: boolean; url?
     const options = {
       hostname: 'api.github.com',
       port: 443,
-      path: `/repos/gwicho38/lsh/actions/runs?per_page=5`,
+      // Scope to the BUILD workflow only. Querying all workflows let a flaky
+      // security scan (e.g. Codacy timing out on a download) read as "build failing".
+      path: `/repos/gwicho38/lsh/actions/workflows/node.js.yml/runs?branch=main&per_page=5`,
       method: 'GET',
       headers: {
         'User-Agent': 'lsh-cli',
@@ -146,24 +167,9 @@ async function checkCIStatus(_version: string): Promise<{ passing: boolean; url?
         try {
           if (res.statusCode === 200) {
             const ghData = JSON.parse(data);
-            const runs = ghData.workflow_runs || [];
-
-            // Find the most recent workflow run for main branch
-            const mainRuns = (runs as GitHubWorkflowRun[]).filter((run) =>
-              run.head_branch === 'main' && run.status === 'completed'
-            );
-
-            if (mainRuns.length > 0) {
-              const latestRun = mainRuns[0];
-              const passing = latestRun.conclusion === 'success';
-              resolve({
-                passing,
-                url: latestRun.html_url,
-              });
-            } else {
-              // No completed runs found, assume passing
-              resolve({ passing: true });
-            }
+            const runs = (ghData.workflow_runs || []) as GitHubWorkflowRun[];
+            // The path is already scoped to node.js.yml on main; decide via the pure helper.
+            resolve(evaluateBuildRuns(runs));
           } else {
             // If we can't check CI, don't block the update
             resolve({ passing: true });

--- a/types/commands/self.d.ts
+++ b/types/commands/self.d.ts
@@ -3,5 +3,24 @@
  * Provides utilities for updating and maintaining the CLI
  */
 import { Command } from 'commander';
+/** GitHub workflow run (minimal interface for CI check) */
+interface GitHubWorkflowRun {
+    head_branch: string;
+    status: string;
+    conclusion: string;
+    html_url: string;
+}
 declare const selfCommand: Command;
+/**
+ * Decide build status from the build workflow's runs (pure, unit-testable).
+ *
+ * Only a real `failure` on the most recent COMPLETED run blocks an update.
+ * `cancelled` / `skipped` / `null` are infra noise — the build is frequently
+ * cancelled by concurrency on the self-hosted runner — and must NOT be reported
+ * as a failing build. No completed runs → treat as passing (don't block).
+ */
+export declare function evaluateBuildRuns(runs: GitHubWorkflowRun[]): {
+    passing: boolean;
+    url?: string;
+};
 export default selfCommand;


### PR DESCRIPTION
## Problem
`lsh self update` reported **"build failing for the latest version"** when the build was fine. `checkCIStatus` took the latest completed run of **any** workflow and treated non-`success` as failing — so a flaky **Codacy** scan (timed out downloading `codeql-action`, 100s HttpClient timeout) read as a failing build. The actual `Node.js CI` was just queued on the self-hosted runner / cancelled by concurrency.

## Fix
- Query the **build workflow only**: `actions/workflows/node.js.yml/runs?branch=main`.
- Only a real `failure` blocks; `cancelled`/`skipped`/`null` are infra noise.
- Logic extracted to a pure, unit-tested `evaluateBuildRuns()` (6-case regression test).

## Before / After
**Before:** flaky security scan failure → "build failing" → blocks/​warns update.
**After:** only a genuine `node.js.yml` failure blocks; transient scan/cancel noise ignored.

## Verification
typecheck/build/lint 0 errors · new test 6/6 · full suite 998 passed.

## Summary by Sourcery

Refine the `lsh self update` CI check so it only blocks updates on genuine failures of the main build workflow, and add regression coverage and documentation for the behavior.

Bug Fixes:
- Prevent `lsh self update` from reporting the build as failing due to non-build or transient workflow issues by scoping CI status checks to the Node.js build workflow and only treating explicit failures as blocking.

Enhancements:
- Extract CI run evaluation into a pure helper function to simplify and clarify build status determination logic.

Documentation:
- Add 3.5.1 release notes describing the fix to false "build failing" reports in `lsh self update`.

Tests:
- Add regression tests for build run evaluation to ensure only real build failures block self-update and transient or non-completed runs are treated as passing.

Chores:
- Bump package version from 3.5.0 to 3.5.1 for the patch release.