### PR TITLE
ci(codacy): hosted runner + harden against transient download timeout

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -34,7 +34,12 @@ jobs:
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     name: Codacy Security Scan
-    runs-on: [self-hosted, linux, x64]
+    # github-hosted (free for this public repo). The self-hosted runner intermittently
+    # timed out fetching the codeql-action tarball from codeload.github.com (100s
+    # HttpClient timeout), failing this informational scan. Hosted runners have fast
+    # GitHub network + action caching, avoiding the codeload download timeout.
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout code
@@ -56,8 +61,11 @@ jobs:
           # This will handover control about PR rejection to the GitHub side
           max-allowed-issues: 2147483647
 
-      # Upload the SARIF file generated in the previous step
+      # Upload the SARIF file generated in the previous step.
+      # continue-on-error: a transient codeql-action download/upload hiccup must not
+      # fail this informational scan (results aren't a required check).
       - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@v2
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Problem
The Codacy scan ran on the self-hosted runner and intermittently failed fetching the `codeql-action` tarball from codeload.github.com (`HttpClient.Timeout of 100 seconds`, 3 attempts). That failed the informational scan — and pre-3.5.1 it tripped a false "build failing" in `lsh self update`.

## Fix
- `runs-on` → `ubuntu-latest` (github-hosted; fast GitHub network + action caching; free for this public repo). Directly addresses the codeload download timeout.
- Bump deprecated `github/codeql-action/upload-sarif@v2` → `@v3`.
- `continue-on-error: true` on the SARIF upload — a transient download/upload hiccup must not fail an informational scan (not a required check).
- `timeout-minutes: 15` to avoid hangs.

## Before / After
**Before:** self-hosted → codeload tarball fetch times out → scan fails (and confused `self update`).
**After:** hosted runner pulls/caches the action reliably; SARIF upload non-fatal; bounded runtime.

CI-only change — no package/version impact. Other CI/test jobs stay self-hosted.

## Summary by Sourcery

Run the Codacy security scan on a GitHub-hosted runner and make the workflow resilient to transient CodeQL upload failures.

CI:
- Switch the Codacy workflow from a self-hosted runner to `ubuntu-latest` with a 15-minute timeout to reduce network-related timeouts.
- Upgrade the CodeQL SARIF upload action from v2 to v3 and allow the upload step to continue on error so transient issues do not fail the informational scan.