### PR TITLE
ci(codacy): raise timeout 15->30 (full scan runs long)

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -39,7 +39,9 @@ jobs:
     # HttpClient timeout), failing this informational scan. Hosted runners have fast
     # GitHub network + action caching, avoiding the codeload download timeout.
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Codacy full analysis runs long (>15 min observed); 30 bounds runaways without
+    # cutting off a normal scan.
+    timeout-minutes: 30
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout code


### PR DESCRIPTION
Follow-up to #190. The hosted-runner move fixed the codeload download timeout (the CLI now runs without the fetch failure), but `timeout-minutes: 15` cut the Codacy CLI off mid-analysis (~15m → run cancelled). Raise to 30.

## Summary by Sourcery

CI:
- Raise the Codacy analysis job timeout in the GitHub Actions workflow from 15 to 30 minutes.