### PR TITLE
refactor(discovery): DiscoveryBackend seam (Phase 1 of #194)

### DIFF
--- a/__tests__/discovery-backend.test.ts
+++ b/__tests__/discovery-backend.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for the discovery backend seam (issue #194, Phase 1).
+ * IpnsDiscoveryBackend logic is verified with injected deps + a fake IPFSSync —
+ * no network / Kubo required.
+ */
+import { describe, it, expect, jest } from '@jest/globals';
+import {
+  IpnsDiscoveryBackend,
+  getDiscoveryBackend,
+  type IpnsBackendDeps,
+} from '../src/lib/discovery-backend.js';
+
+const KEY_INFO = { keyName: 'lsh-deadbeef', seed: Buffer.alloc(32) };
+
+function makeSync(over: Partial<Record<'getApiUrl' | 'publishToIPNS' | 'resolveIPNS', any>> = {}) {
+  return {
+    getApiUrl: over.getApiUrl ?? jest.fn(() => 'http://127.0.0.1:5001/api/v0'),
+    publishToIPNS: over.publishToIPNS ?? jest.fn(async () => 'k51-published'),
+    resolveIPNS: over.resolveIPNS ?? jest.fn(async () => 'QmCID'),
+  } as any;
+}
+
+function makeDeps(over: Partial<IpnsBackendDeps> = {}): IpnsBackendDeps {
+  return {
+    deriveKeyInfo: over.deriveKeyInfo ?? jest.fn(() => KEY_INFO) as any,
+    ensureKeyImported: over.ensureKeyImported ?? (jest.fn(async () => 'k51-name') as any),
+  };
+}
+
+describe('IpnsDiscoveryBackend', () => {
+  it('has id "ipns"', () => {
+    expect(new IpnsDiscoveryBackend(makeSync(), makeDeps()).id).toBe('ipns');
+  });
+
+  describe('publish', () => {
+    it('derives the key, imports it, and publishes the CID under the derived keyName', async () => {
+      const sync = makeSync();
+      const deps = makeDeps();
+      const backend = new IpnsDiscoveryBackend(sync, deps);
+
+      const name = await backend.publish({ secretsKey: 'k', repoName: 'repo', env: 'dev', cid: 'QmCID' });
+
+      expect(deps.deriveKeyInfo).toHaveBeenCalledWith('k', 'repo', 'dev');
+      expect(deps.ensureKeyImported).toHaveBeenCalledWith('http://127.0.0.1:5001/api/v0', KEY_INFO);
+      expect(sync.publishToIPNS).toHaveBeenCalledWith('QmCID', 'lsh-deadbeef');
+      expect(name).toBe('k51-published');
+    });
+
+    it('returns null and does not publish when the key cannot be imported', async () => {
+      const sync = makeSync();
+      const backend = new IpnsDiscoveryBackend(sync, makeDeps({ ensureKeyImported: jest.fn(async () => null) as any }));
+
+      const name = await backend.publish({ secretsKey: 'k', repoName: 'r', env: 'dev', cid: 'QmCID' });
+
+      expect(name).toBeNull();
+      expect(sync.publishToIPNS).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('resolve', () => {
+    it('returns the resolved CID and the pointer name', async () => {
+      const sync = makeSync();
+      const backend = new IpnsDiscoveryBackend(sync, makeDeps());
+
+      const res = await backend.resolve({ secretsKey: 'k', repoName: 'r', env: 'dev' });
+
+      expect(sync.resolveIPNS).toHaveBeenCalledWith('k51-name');
+      expect(res).toEqual({ cid: 'QmCID', name: 'k51-name' });
+    });
+
+    it('returns nulls and does not resolve when the key cannot be imported', async () => {
+      const sync = makeSync();
+      const backend = new IpnsDiscoveryBackend(sync, makeDeps({ ensureKeyImported: jest.fn(async () => null) as any }));
+
+      const res = await backend.resolve({ secretsKey: 'k', repoName: 'r', env: 'dev' });
+
+      expect(res).toEqual({ cid: null, name: null });
+      expect(sync.resolveIPNS).not.toHaveBeenCalled();
+    });
+
+    it('returns null cid when the name resolves to nothing', async () => {
+      const sync = makeSync({ resolveIPNS: jest.fn(async () => null) });
+      const backend = new IpnsDiscoveryBackend(sync, makeDeps());
+
+      const res = await backend.resolve({ secretsKey: 'k', repoName: 'r', env: 'dev' });
+
+      expect(res).toEqual({ cid: null, name: 'k51-name' });
+    });
+  });
+});
+
+describe('getDiscoveryBackend', () => {
+  it('returns the IPNS backend (behaviour-preserving default)', () => {
+    expect(getDiscoveryBackend(makeSync()).id).toBe('ipns');
+  });
+});

--- a/src/lib/discovery-backend.ts
+++ b/src/lib/discovery-backend.ts
@@ -1,0 +1,100 @@
+/**
+ * Discovery backend seam.
+ *
+ * "Discovery" = mapping a key-derived pointer to the latest content CID
+ * (publish on push, resolve on pull). Today the only backend is IPNS over the
+ * DHT (`IpnsDiscoveryBackend`), which is what LSH has always used — this module
+ * just extracts that behind an interface so additional backends (e.g. a durable
+ * w3name pointer; see issue #194) can be added without touching the storage layer.
+ *
+ * This is a behaviour-preserving refactor: `getDiscoveryBackend()` returns the
+ * IPNS backend, identical to the previous inline logic.
+ */
+
+import type { IPFSSync } from './ipfs-sync.js';
+import {
+  deriveKeyInfo as defaultDeriveKeyInfo,
+  ensureKeyImported as defaultEnsureKeyImported,
+  type IPNSKeyInfo,
+} from './ipns-key-manager.js';
+
+export interface DiscoveryPublishParams {
+  secretsKey: string;
+  repoName: string;
+  env: string;
+  cid: string;
+}
+
+export interface DiscoveryResolveParams {
+  secretsKey: string;
+  repoName: string;
+  env: string;
+}
+
+export interface DiscoveryResolveResult {
+  /** Latest CID for the derived pointer, or null if unresolved. */
+  cid: string | null;
+  /** The pointer name (IPNS name / peer id), or null if the key couldn't be prepared. */
+  name: string | null;
+}
+
+export interface DiscoveryBackend {
+  /** Stable identifier, e.g. 'ipns'. */
+  readonly id: string;
+  /** Publish `cid` under the key-derived pointer. Returns the pointer name, or null on failure. */
+  publish(params: DiscoveryPublishParams): Promise<string | null>;
+  /** Resolve the latest CID for the key-derived pointer. */
+  resolve(params: DiscoveryResolveParams): Promise<DiscoveryResolveResult>;
+}
+
+/** Injectable dependencies (defaults are the real implementations; tests override). */
+export interface IpnsBackendDeps {
+  deriveKeyInfo: (secretsKey: string, repoName: string, env: string) => IPNSKeyInfo;
+  ensureKeyImported: (kuboApiUrl: string, keyInfo: IPNSKeyInfo) => Promise<string | null>;
+}
+
+/**
+ * IPNS-over-DHT discovery: derive a deterministic ed25519 key from the secrets
+ * key, import it into the local Kubo keystore, and publish/resolve via IPNS.
+ */
+export class IpnsDiscoveryBackend implements DiscoveryBackend {
+  readonly id = 'ipns';
+
+  constructor(
+    private readonly ipfsSync: Pick<IPFSSync, 'getApiUrl' | 'publishToIPNS' | 'resolveIPNS'>,
+    private readonly deps: IpnsBackendDeps = {
+      deriveKeyInfo: defaultDeriveKeyInfo,
+      ensureKeyImported: defaultEnsureKeyImported,
+    },
+  ) {}
+
+  async publish({ secretsKey, repoName, env, cid }: DiscoveryPublishParams): Promise<string | null> {
+    const keyInfo = this.deps.deriveKeyInfo(secretsKey, repoName, env);
+    const ipnsName = await this.deps.ensureKeyImported(this.ipfsSync.getApiUrl(), keyInfo);
+    if (!ipnsName) {
+      return null;
+    }
+    return this.ipfsSync.publishToIPNS(cid, keyInfo.keyName);
+  }
+
+  async resolve({ secretsKey, repoName, env }: DiscoveryResolveParams): Promise<DiscoveryResolveResult> {
+    const keyInfo = this.deps.deriveKeyInfo(secretsKey, repoName, env);
+    const ipnsName = await this.deps.ensureKeyImported(this.ipfsSync.getApiUrl(), keyInfo);
+    if (!ipnsName) {
+      return { cid: null, name: null };
+    }
+    const cid = await this.ipfsSync.resolveIPNS(ipnsName);
+    return { cid, name: ipnsName };
+  }
+}
+
+/**
+ * Select the discovery backend. Currently always IPNS (behaviour-preserving).
+ * Phase 2 (issue #194) will read a `LSH_DISCOVERY` setting to choose/compose
+ * backends (e.g. w3name primary + ipns fallback).
+ */
+export function getDiscoveryBackend(
+  ipfsSync: Pick<IPFSSync, 'getApiUrl' | 'publishToIPNS' | 'resolveIPNS'>,
+): DiscoveryBackend {
+  return new IpnsDiscoveryBackend(ipfsSync);
+}

--- a/src/lib/ipfs-secrets-storage.ts
+++ b/src/lib/ipfs-secrets-storage.ts
@@ -16,7 +16,7 @@ import * as crypto from 'crypto';
 import { Secret } from './secrets-manager.js';
 import { createLogger } from './logger.js';
 import { getIPFSSync } from './ipfs-sync.js';
-import { deriveKeyInfo, ensureKeyImported } from './ipns-key-manager.js';
+import { getDiscoveryBackend } from './discovery-backend.js';
 import { ENV_VARS, DEFAULTS } from '../constants/index.js';
 import { extractErrorMessage } from './lsh-error.js';
 
@@ -134,17 +134,14 @@ export class IPFSSecretsStorage {
         try {
           const repoName = gitRepo || DEFAULTS.DEFAULT_ENVIRONMENT;
           const env = environment || DEFAULTS.DEFAULT_ENVIRONMENT;
-          const keyInfo = deriveKeyInfo(encryptionKey, repoName, env);
-          const ipnsName = await ensureKeyImported(ipfsSync.getApiUrl(), keyInfo);
+          const discovery = getDiscoveryBackend(ipfsSync);
+          const publishedName = await discovery.publish({ secretsKey: encryptionKey, repoName, env, cid });
 
-          if (ipnsName) {
-            const publishedName = await ipfsSync.publishToIPNS(cid, keyInfo.keyName);
-            if (publishedName) {
-              metadata.ipns_name = publishedName;
-              this.metadata[this.getMetadataKey(gitRepo, environment)] = metadata;
-              await this.saveMetadata();
-              logger.info(`   🔗 Published to IPNS: ${publishedName}`);
-            }
+          if (publishedName) {
+            metadata.ipns_name = publishedName;
+            this.metadata[this.getMetadataKey(gitRepo, environment)] = metadata;
+            await this.saveMetadata();
+            logger.info(`   🔗 Published to IPNS: ${publishedName}`);
           }
         } catch (error) {
           logger.error(
@@ -188,12 +185,13 @@ export class IPFSSecretsStorage {
         try {
           const repoName = gitRepo || DEFAULTS.DEFAULT_ENVIRONMENT;
           const env = environment || DEFAULTS.DEFAULT_ENVIRONMENT;
-          const keyInfo = deriveKeyInfo(encryptionKey, repoName, env);
-          const ipnsName = await ensureKeyImported(ipfsSync.getApiUrl(), keyInfo);
+          const discovery = getDiscoveryBackend(ipfsSync);
+          const resolved = await discovery.resolve({ secretsKey: encryptionKey, repoName, env });
+          const ipnsName = resolved.name;
 
           if (ipnsName) {
             logger.info(`   🔍 Resolving via IPNS: ${ipnsName.substring(0, 20)}...`);
-            resolvedCid = await ipfsSync.resolveIPNS(ipnsName);
+            resolvedCid = resolved.cid;
 
             if (resolvedCid) {
               logger.info(`   ✅ IPNS resolved to CID: ${resolvedCid}`);


### PR DESCRIPTION
Phase 1 of #194 (durable secret discovery). **Behaviour-preserving refactor — no functional change.**

## What
- New `src/lib/discovery-backend.ts`: `DiscoveryBackend` interface (`publish`/`resolve` a key-derived pointer→CID) + `IpnsDiscoveryBackend` wrapping the current IPNS-over-DHT logic + `getDiscoveryBackend()` factory.
- `ipfs-secrets-storage.ts` push/pull now route through the seam instead of inline `deriveKeyInfo`/`ensureKeyImported`/`publishToIPNS`/`resolveIPNS`.
- Backend deps are injectable → unit-tested without network/Kubo.

## Why
Sets up Phase 2 to add a **durable w3name** backend (+ IPNS fallback) without touching the storage layer. (Ceramic was ruled out in the Phase-0 spike — no free endpoint + actively deprecated; see #194.)

## Verification
- typecheck/build 0 errors; lint 0 errors
- new `discovery-backend.test.ts` — 7/7
- full suite — 1005 passed, 0 failed
- IPNS remains the only backend; `getDiscoveryBackend()` returns it (identical behaviour)

## Summary by Sourcery

Introduce a discovery backend abstraction for IPFS secrets storage while preserving existing IPNS behaviour.

Enhancements:
- Extract a DiscoveryBackend interface and IpnsDiscoveryBackend implementation to encapsulate key-derived pointer publication and resolution.
- Refactor IPFSSecretsStorage push/pull flows to use the discovery backend seam instead of inline IPNS key management logic.

Tests:
- Add unit tests for IpnsDiscoveryBackend and getDiscoveryBackend using injected dependencies and a fake IPFSSync to avoid network access.