### PR TITLE
feat(discovery): durable w3name pointer backend (Phase 2 of #194)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,16 @@ removed code.
 ```bash
 LSH_SECRETS_KEY=<64-char-hex>   # Required: AES-256 key (from `lsh key`)
 LSH_PIN_SERVICE=<service-name>  # Optional: Kubo remote pinning service for durable sync
+LSH_DISCOVERY=w3name,ipns       # Optional: pointer discovery backends (priority order);
+                                # default durable w3name + DHT-IPNS fallback (issue #194)
 ```
+
+**Discovery layer** (`src/lib/discovery-backend.ts`): the `key→CID` pointer is published/resolved
+through a `DiscoveryBackend`. Default is a composite of `w3name` (durable signed IPNS via
+name.web3.storage — no account, survives offline nodes) + `ipns` (DHT fallback); push dual-writes,
+pull resolves w3name→ipns→cache. `w3name-pointer.ts` lazily imports `w3name`/`@libp2p/crypto`. The
+w3name name is identical to the Kubo-derived IPNS name (same seed). Content availability still needs
+a pin (`LSH_PIN_SERVICE`); discovery durability ≠ byte durability.
 
 There are no API/JWT/webhook/Supabase environment variables — those features were removed.
 

--- a/README.md
+++ b/README.md
@@ -326,6 +326,11 @@ LSH_SECRETS_KEY=<your-encryption-key>
 # Optional - name of a kubo remote pinning service for durable sync
 # (configure once with: ipfs pin remote service add <name> <endpoint> <key>)
 LSH_PIN_SERVICE=<service-name>
+
+# Optional - pointer discovery backends, comma-separated in priority order.
+# Default 'w3name,ipns': durable w3name (signed IPNS via name.web3.storage, no
+# account, no DHT TTL) with IPNS-over-DHT fallback. Set 'ipns' for DHT-only.
+LSH_DISCOVERY=w3name,ipns
 ```
 
 ### Configuration Files

--- a/__tests__/discovery-backend.test.ts
+++ b/__tests__/discovery-backend.test.ts
@@ -6,8 +6,12 @@
 import { describe, it, expect, jest } from '@jest/globals';
 import {
   IpnsDiscoveryBackend,
+  W3nameDiscoveryBackend,
+  CompositeDiscoveryBackend,
   getDiscoveryBackend,
   type IpnsBackendDeps,
+  type W3nameBackendDeps,
+  type DiscoveryBackend,
 } from '../src/lib/discovery-backend.js';
 
 const KEY_INFO = { keyName: 'lsh-deadbeef', seed: Buffer.alloc(32) };
@@ -89,8 +93,119 @@ describe('IpnsDiscoveryBackend', () => {
   });
 });
 
-describe('getDiscoveryBackend', () => {
-  it('returns the IPNS backend (behaviour-preserving default)', () => {
+function makeW3Deps(over: Partial<W3nameBackendDeps> = {}): W3nameBackendDeps {
+  return {
+    deriveKeyInfo: over.deriveKeyInfo ?? (jest.fn(() => KEY_INFO) as any),
+    publish: over.publish ?? (jest.fn(async () => 'k51-w3') as any),
+    resolve: over.resolve ?? (jest.fn(async () => ({ cid: 'QmW3', name: 'k51-w3' })) as any),
+  };
+}
+
+describe('W3nameDiscoveryBackend', () => {
+  it('has id "w3name"', () => {
+    expect(new W3nameDiscoveryBackend(makeW3Deps()).id).toBe('w3name');
+  });
+
+  it('publish derives the seed and publishes the CID, returning the name', async () => {
+    const deps = makeW3Deps();
+    const name = await new W3nameDiscoveryBackend(deps).publish({ secretsKey: 'k', repoName: 'r', env: 'dev', cid: 'QmW3' });
+    expect(deps.deriveKeyInfo).toHaveBeenCalledWith('k', 'r', 'dev');
+    expect(deps.publish).toHaveBeenCalledWith(KEY_INFO.seed, 'QmW3');
+    expect(name).toBe('k51-w3');
+  });
+
+  it('resolve returns the cid and name from the w3name pointer', async () => {
+    const res = await new W3nameDiscoveryBackend(makeW3Deps()).resolve({ secretsKey: 'k', repoName: 'r', env: 'dev' });
+    expect(res).toEqual({ cid: 'QmW3', name: 'k51-w3' });
+  });
+});
+
+// Minimal fake backend for composite tests.
+function fakeBackend(id: string, opts: {
+  publish?: () => Promise<string | null>;
+  resolve?: () => Promise<{ cid: string | null; name: string | null }>;
+} = {}): DiscoveryBackend {
+  return {
+    id,
+    publish: opts.publish ?? (async () => `name-${id}`),
+    resolve: opts.resolve ?? (async () => ({ cid: `cid-${id}`, name: `name-${id}` })),
+  };
+}
+
+describe('CompositeDiscoveryBackend', () => {
+  it('id joins child ids', () => {
+    expect(new CompositeDiscoveryBackend([fakeBackend('w3name'), fakeBackend('ipns')]).id).toBe('w3name+ipns');
+  });
+
+  it('publish dual-writes to ALL backends and returns the first name', async () => {
+    const a = jest.fn(async () => 'name-a');
+    const b = jest.fn(async () => 'name-b');
+    const name = await new CompositeDiscoveryBackend([
+      fakeBackend('a', { publish: a }),
+      fakeBackend('b', { publish: b }),
+    ]).publish({ secretsKey: 'k', repoName: 'r', env: 'dev', cid: 'Qm' });
+    expect(a).toHaveBeenCalled();
+    expect(b).toHaveBeenCalled();
+    expect(name).toBe('name-a');
+  });
+
+  it('publish continues to other backends when one throws', async () => {
+    const b = jest.fn(async () => 'name-b');
+    const name = await new CompositeDiscoveryBackend([
+      fakeBackend('a', { publish: async () => { throw new Error('boom'); } }),
+      fakeBackend('b', { publish: b }),
+    ]).publish({ secretsKey: 'k', repoName: 'r', env: 'dev', cid: 'Qm' });
+    expect(b).toHaveBeenCalled();
+    expect(name).toBe('name-b');
+  });
+
+  it('resolve returns the first backend that yields a cid (durable wins)', async () => {
+    const second = jest.fn(async () => ({ cid: 'cid-2', name: 'n2' }));
+    const res = await new CompositeDiscoveryBackend([
+      fakeBackend('a', { resolve: async () => ({ cid: null, name: 'n1' }) }),
+      fakeBackend('b', { resolve: second }),
+    ]).resolve({ secretsKey: 'k', repoName: 'r', env: 'dev' });
+    expect(res).toEqual({ cid: 'cid-2', name: 'n2' });
+  });
+
+  it('resolve falls through and returns nulls (with first name) when none resolve', async () => {
+    const res = await new CompositeDiscoveryBackend([
+      fakeBackend('a', { resolve: async () => ({ cid: null, name: 'n1' }) }),
+      fakeBackend('b', { resolve: async () => ({ cid: null, name: 'n2' }) }),
+    ]).resolve({ secretsKey: 'k', repoName: 'r', env: 'dev' });
+    expect(res).toEqual({ cid: null, name: 'n1' });
+  });
+});
+
+describe('getDiscoveryBackend (LSH_DISCOVERY config)', () => {
+  const prev = process.env.LSH_DISCOVERY;
+  afterEach(() => {
+    if (prev === undefined) delete process.env.LSH_DISCOVERY;
+    else process.env.LSH_DISCOVERY = prev;
+  });
+
+  it('defaults to durable w3name + ipns fallback', () => {
+    delete process.env.LSH_DISCOVERY;
+    expect(getDiscoveryBackend(makeSync()).id).toBe('w3name+ipns');
+  });
+
+  it('honors LSH_DISCOVERY=ipns (single backend)', () => {
+    process.env.LSH_DISCOVERY = 'ipns';
+    expect(getDiscoveryBackend(makeSync()).id).toBe('ipns');
+  });
+
+  it('honors LSH_DISCOVERY=w3name (single backend)', () => {
+    process.env.LSH_DISCOVERY = 'w3name';
+    expect(getDiscoveryBackend(makeSync()).id).toBe('w3name');
+  });
+
+  it('honors custom order LSH_DISCOVERY=ipns,w3name', () => {
+    process.env.LSH_DISCOVERY = 'ipns,w3name';
+    expect(getDiscoveryBackend(makeSync()).id).toBe('ipns+w3name');
+  });
+
+  it('ignores unknown backends and falls back to ipns when nothing valid', () => {
+    process.env.LSH_DISCOVERY = 'bogus';
     expect(getDiscoveryBackend(makeSync()).id).toBe('ipns');
   });
 });

--- a/docs/releases/3.6.0.md
+++ b/docs/releases/3.6.0.md
@@ -1,0 +1,53 @@
+# 3.6.0 — Durable secret discovery via w3name (issue #194)
+
+Adds a durable discovery layer so `lsh pull` keeps resolving even when the publishing node
+goes offline — fixing the IPNS-over-DHT expiry that caused "Could not resolve secrets from
+network" once no node republished the record (~24–48h DHT TTL).
+
+## What changed
+
+The `key→CID` pointer now goes through a pluggable **`DiscoveryBackend`** (`src/lib/discovery-backend.ts`):
+
+- **`w3name`** (new, default): publishes a **signed IPNS record** to Storacha's w3name
+  (`name.web3.storage`) — durable, no DHT TTL, **no account / no auth**. The w3name name is
+  **identical** to the Kubo-derived IPNS name (same key-derived seed), so it's one logical pointer.
+- **`ipns`** (existing): IPNS-over-DHT, kept as fallback + backward compat.
+
+**Default `LSH_DISCOVERY=w3name,ipns`:** push **dual-writes** to both; pull resolves
+**w3name → ipns → local cache**. Set `LSH_DISCOVERY=ipns` for DHT-only (previous behavior).
+
+## Before / After
+
+```mermaid
+flowchart LR
+    subgraph Before
+      P1["push"] --> D1["IPNS record → DHT only"]
+      D1 -->|"publisher offline / ~24-48h TTL"| X1["record expires → pull fails"]
+    end
+    subgraph After
+      P2["push"] --> W["w3name (durable, hosted)"]
+      P2 --> D2["IPNS → DHT (fallback)"]
+      Pull["pull"] --> R{"resolve"}
+      R -->|"1"| W
+      R -->|"2"| D2
+      R -->|"3"| C["local cache"]
+    end
+```
+
+## Important: discovery ≠ availability
+
+w3name makes the **pointer** durable. The **encrypted bytes** still need a host — keep a node
+online or configure a pin service (`LSH_PIN_SERVICE`). A bundled default free pinner (4EVERLAND)
+is planned next (issue #194, Phase 3).
+
+## Notes
+- `w3name` + `@libp2p/crypto` added as deps; **lazily imported** (only loaded when w3name is used).
+- w3name calls are timeout-bounded (resolve 10s / publish 15s) and best-effort — a w3name hiccup
+  never blocks push/pull (IPNS fallback covers it).
+- Behavior change: pushes now also publish to w3name by default (free, best-effort).
+
+## Verification
+- typecheck/build 0 errors; lint 0 errors
+- discovery seam: 19 unit tests (IPNS + w3name backends, composite dual-write/fallback, config parsing)
+- full suite: 1017 passed; coverage ≥ threshold (discovery-backend.ts 100%)
+- Phase-2 spike confirmed seed→w3name name == Kubo IPNS name + publish/resolve round-trip

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "lsh-framework",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lsh-framework",
-      "version": "3.5.1",
+      "version": "3.6.0",
       "license": "MIT",
       "dependencies": {
+        "@libp2p/crypto": "^5.1.19",
         "@supabase/supabase-js": "^2.57.4",
         "bcrypt": "^6.0.0",
         "chalk": "^5.3.0",
@@ -26,7 +27,8 @@
         "ora": "^9.0.0",
         "pg": "^8.16.3",
         "proper-lockfile": "^4.1.2",
-        "smol-toml": "^1.3.1"
+        "smol-toml": "^1.3.1",
+        "w3name": "^1.1.3"
       },
       "bin": {
         "lsh": "dist/cli.js"
@@ -568,6 +570,34 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@chainsafe/is-ip": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.1.0.tgz",
+      "integrity": "sha512-KIjt+6IfysQ4GCv66xihEitBjvhU/bixbbbFxdJ1sqCp4uJ0wuZiYBPhksZoy4lfaF0k9cwNzY5upEW/VWdw3w==",
+      "license": "MIT"
+    },
+    "node_modules/@chainsafe/netmask": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/netmask/-/netmask-2.0.0.tgz",
+      "integrity": "sha512-I3Z+6SWUoaljh3TBzCnCxjlUyN8tA+NAk5L6m9IxvCf1BENQTePzPMis97CoN/iMW1St3WN+AWCCRp+TTBRiDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1"
+      }
+    },
+    "node_modules/@dnsquery/dns-packet": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@dnsquery/dns-packet/-/dns-packet-6.1.1.tgz",
+      "integrity": "sha512-WXTuFvL3G+74SchFAtz3FgIYVOe196ycvGsMgvSH/8Goptb1qpIQtIuM4SOK9G9lhMWYpHxnXyy544ZhluFOew==",
+      "license": "MIT",
+      "dependencies": {
+        "@leichtgewicht/ip-codec": "^2.0.4",
+        "utf8-codec": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
@@ -2002,6 +2032,95 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@leichtgewicht/ip-codec": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
+      "license": "MIT"
+    },
+    "node_modules/@libp2p/crypto": {
+      "version": "5.1.19",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.19.tgz",
+      "integrity": "sha512-hYNeHQpUSwLPopWCgDf6OklOvVwJPS/vYZOiBG3VXPIzx5AkONBOfdkgVwB4YsIBH2V6z+TMgMH0yXUZsMurPA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@libp2p/interface": "^3.2.3",
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1",
+        "multiformats": "^14.0.0",
+        "protons-runtime": "^6.0.1",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@libp2p/interface": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.3.tgz",
+      "integrity": "sha512-OKZFrY+x8IYl4Fr/YWjh4s6+uks5zQBIAdg2cl+zaRUpPORfk1ELI4r+eB+fUlXR9mHDsQylSSzmAqi0drDfiA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@multiformats/dns": "^1.0.6",
+        "@multiformats/multiaddr": "^13.0.3",
+        "main-event": "^1.0.1",
+        "multiformats": "^14.0.0",
+        "progress-events": "^1.1.0",
+        "uint8arraylist": "^2.4.8"
+      }
+    },
+    "node_modules/@libp2p/logger": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-6.2.8.tgz",
+      "integrity": "sha512-oPTkWJhYvhk8fjInH1ySyUDC/LLuqHsVqpNprtImd/64lnRHInV0EbwpRYwjdPNXAxYXDU/eQJzyqMWUNnN4+A==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@libp2p/interface": "^3.2.3",
+        "@multiformats/multiaddr": "^13.0.3",
+        "interface-datastore": "^9.0.1",
+        "multiformats": "^14.0.0",
+        "weald": "^1.1.0"
+      }
+    },
+    "node_modules/@multiformats/dns": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@multiformats/dns/-/dns-1.0.13.tgz",
+      "integrity": "sha512-yr4bxtA3MbvJ+2461kYIYMsiiZj/FIqKI64hE4SdvWJUdWF9EtZLar38juf20Sf5tguXKFUruluswAO6JsjS2w==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@dnsquery/dns-packet": "^6.1.1",
+        "@libp2p/interface": "^3.1.0",
+        "hashlru": "^2.3.0",
+        "p-queue": "^9.0.0",
+        "progress-events": "^1.0.0",
+        "uint8arrays": "^5.0.2"
+      }
+    },
+    "node_modules/@multiformats/dns/node_modules/multiformats": {
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
+      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/@multiformats/dns/node_modules/uint8arrays": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
+      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
+    "node_modules/@multiformats/multiaddr": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-13.0.3.tgz",
+      "integrity": "sha512-mEqqJ4r3a/uuFMTpRkU316wGNIDQNhuVWpm+ebKTQeYsfv9jXbPONWM6VVnj3KGUrwfsX7GZOyp4TFqEA2SPCw==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "multiformats": "^14.0.0",
+        "uint8-varint": "^3.0.0",
+        "uint8arrays": "^6.1.1"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
@@ -2019,6 +2138,33 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -2801,9 +2947,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2818,9 +2961,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2835,9 +2975,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2852,9 +2989,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2869,9 +3003,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2886,9 +3017,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2903,9 +3031,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2920,9 +3045,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2937,9 +3059,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2954,9 +3073,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3037,6 +3153,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/abort-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/abort-error/-/abort-error-1.0.2.tgz",
+      "integrity": "sha512-lVgvB2NyPLqbXXhVmXcYFTC1x5K7CiVdPgdY7LGgFQWC8506oN01sPN3i9cl9ynuwF4iJ0TS9exnR7cZ9FuX4w==",
+      "license": "Apache-2.0 OR MIT"
     },
     "node_modules/accepts": {
       "version": "2.0.0",
@@ -3515,6 +3637,15 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/cborg": {
+      "version": "4.5.8",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.5.8.tgz",
+      "integrity": "sha512-6/viltD51JklRhq4L7jC3zgy6gryuG5xfZ3kzpE+PravtyeQLeQmCYLREhQH7pWENg5pY4Yu/XCd6a7dKScVlw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "cborg": "lib/bin.js"
+      }
     },
     "node_modules/chalk": {
       "version": "5.6.2",
@@ -4232,6 +4363,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -4753,6 +4890,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hashlru": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
+      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A==",
+      "license": "MIT"
+    },
     "node_modules/hasown": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
@@ -4910,6 +5053,37 @@
         }
       }
     },
+    "node_modules/interface-datastore": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-9.0.3.tgz",
+      "integrity": "sha512-NLZa7Mp+0qn48nSwIY/C36da4uVIKzwG2tuEIpaSJArsuB2RrdyDWwkoDUyjsJ+VrMntXz38VSk9vXTx/ZUpAw==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "interface-store": "^7.0.0",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/interface-datastore/node_modules/multiformats": {
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
+      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/interface-datastore/node_modules/uint8arrays": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
+      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
+    "node_modules/interface-store": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-7.0.2.tgz",
+      "integrity": "sha512-KYOPcDH+1peaPhSeoZujR5nwkVeola1EdrnrlHTIM0HRNUs9B0aTsUQMH5kTmIjaQq1BOowoUyoCamgL8IMyww==",
+      "license": "Apache-2.0 OR MIT"
+    },
     "node_modules/ip-address": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
@@ -4926,6 +5100,48 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/ipns": {
+      "version": "10.1.6",
+      "resolved": "https://registry.npmjs.org/ipns/-/ipns-10.1.6.tgz",
+      "integrity": "sha512-mTACIdTBBXY5kbCo3t/M3ycNWbjajLrSXhTvjD0MEGyOUaI3uMv94JbJSHGaJ2xxRlpOrRk1ifToOsyPZiglnA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@libp2p/crypto": "^5.0.0",
+        "@libp2p/interface": "^3.0.2",
+        "@libp2p/logger": "^6.0.4",
+        "cborg": "^5.1.0",
+        "interface-datastore": "^9.0.2",
+        "multiformats": "^13.2.2",
+        "protons-runtime": "^6.0.1",
+        "timestamp-nano": "^1.0.1",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/ipns/node_modules/cborg": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-5.1.1.tgz",
+      "integrity": "sha512-BDbSRIp6XrQXkTc7g+DN0RB9RrDPTUfals2ecWUlt3juPLjbAvy/V72mJcXY0Ehu0Dq/3WpNCOCT68HUTbW+lw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "cborg": "lib/bin.js"
+      }
+    },
+    "node_modules/ipns/node_modules/multiformats": {
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
+      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/ipns/node_modules/uint8arrays": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
+      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "multiformats": "^13.0.0"
       }
     },
     "node_modules/is-arrayish": {
@@ -5098,6 +5314,21 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/it-pushable": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.2.4.tgz",
+      "integrity": "sha512-WSD7Ss4oCRfDZJT4ldLWr0Bom/muY90xxoJ5PQnU3uSKf0kxCOeehqZtiJX1ARqn+ymXGh1bxpDW9bDNHp2ivQ==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "p-defer": "^4.0.0"
+      }
+    },
+    "node_modules/it-stream-types": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-2.0.4.tgz",
+      "integrity": "sha512-tsX+klvMQ53J4Jm2B52vCIs7WD609ck+VS9X2TKMEv7VPY9VwaYKmSWyHek5QS0wHBtP0bWj9KMqCtAHgVKiXw==",
+      "license": "Apache-2.0 OR MIT"
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -6573,6 +6804,12 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/main-event": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/main-event/-/main-event-1.0.4.tgz",
+      "integrity": "sha512-sKazUjIy2Jalv5lkQ446iOcrx8Q7TkaCuk6xfnzg5uUqMusMLDMPmRDmSNE2kjSVpSTJo4j1bQZusS+Ib7Bvrg==",
+      "license": "Apache-2.0 OR MIT"
+    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -6729,6 +6966,12 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/multiformats": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
+      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
+      "license": "Apache-2.0 OR MIT"
     },
     "node_modules/mute-stream": {
       "version": "3.0.0",
@@ -6988,6 +7231,18 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/p-defer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.1.tgz",
+      "integrity": "sha512-Mr5KC5efvAK5VUptYEIopP1bakB85k2IWXaRC0rsh1uwn1L6M0LVml8OIQ4Gudg4oyZakf7FmeRLkMMtZW1i5A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -7015,6 +7270,34 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.0.tgz",
+      "integrity": "sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.4",
+        "p-timeout": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7383,6 +7666,12 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/progress-events": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/progress-events/-/progress-events-1.1.0.tgz",
+      "integrity": "sha512-82DVc5tI36neVB3IjdXR11ztwGuoBc98em9ijzubeZKxI47OlV2Znq6mlPqE5xPDzO2Uw98GHiQSjj2favBCRQ==",
+      "license": "Apache-2.0 OR MIT"
+    },
     "node_modules/proper-lockfile": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
@@ -7392,6 +7681,42 @@
         "graceful-fs": "^4.2.4",
         "retry": "^0.12.0",
         "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/protons-runtime": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-6.0.2.tgz",
+      "integrity": "sha512-hiyjyANwGcgmzc+tXc1/ZcSZhKnl5MDjaVNWkISHBgadaU0sjTgKIKZMZ62d9J9zlSTyKHCs/osPkQ/3Z+7yeA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/protons-runtime/node_modules/multiformats": {
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
+      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/protons-runtime/node_modules/uint8-varint": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.5.tgz",
+      "integrity": "sha512-jeFLbL/x30wBRnWjKE1qVBXeumG46r7XmYkpis955lTQ+blccGKFrOsSMHlxePwYB1pI7L8YPHz1t4jLxEs3nA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^5.0.0"
+      }
+    },
+    "node_modules/protons-runtime/node_modules/uint8arrays": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
+      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "multiformats": "^13.0.0"
       }
     },
     "node_modules/proxy-addr": {
@@ -8107,6 +8432,21 @@
         "node": "*"
       }
     },
+    "node_modules/throttled-queue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/throttled-queue/-/throttled-queue-3.0.0.tgz",
+      "integrity": "sha512-8X5YUdgDHaqy9DmJzoRWK45o2vzBZ7Rt4bT1Mody4TUuYOXSb7paRwDPVspCZiiW4rxZopgZQAwnhI2LU0QwFQ==",
+      "license": "MIT"
+    },
+    "node_modules/timestamp-nano": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/timestamp-nano/-/timestamp-nano-1.0.1.tgz",
+      "integrity": "sha512-4oGOVZWTu5sl89PtCDnhQBSt7/vL1zVEwAfxH1p49JhTosxzVQWYBYFRFZ8nJmo0G6f824iyP/44BFAwIoKvIA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -8320,6 +8660,58 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/uint8-varint": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-3.0.0.tgz",
+      "integrity": "sha512-S4DdpXBaLwKcFo7f0bWzWfHjbZ/i3QhM842qn+ZvHjxqFCfUcEB9SQNcmI69S+zMlcmIcKxsk9Iyw77S2Kxv6Q==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "uint8arraylist": "^3.0.1",
+        "uint8arrays": "^6.1.0"
+      }
+    },
+    "node_modules/uint8-varint/node_modules/uint8arraylist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-3.0.2.tgz",
+      "integrity": "sha512-LDVoq9BQaGJzGDUovEnoX6rpKCvnY/Jbtws4ikwnBzjRbq5qBAFpBZevUEbSmMM87aO0Sp+wOZy2ZXf5yODmXQ==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "uint8arrays": "^6.0.0"
+      }
+    },
+    "node_modules/uint8arraylist": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.9.tgz",
+      "integrity": "sha512-KxWjyEFzchzik3aoQlK66oaoxIReoMo5bQRm1fcjBUZvE8xv/tyR3CTKhjh6K/faV8VaF6hd5pjr45CzbwuwkA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "uint8arrays": "^5.0.1"
+      }
+    },
+    "node_modules/uint8arraylist/node_modules/multiformats": {
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
+      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/uint8arraylist/node_modules/uint8arrays": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
+      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
+    "node_modules/uint8arrays": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-6.1.1.tgz",
+      "integrity": "sha512-iz7JN0XCSZYA111lhFG2Ui9EhFvTNekqSRHw3lvMHq+dzwWy1OQftxFQREEh4rffU0oSoXdQHsk2TiHKVm4fsA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "multiformats": "^14.0.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
@@ -8415,6 +8807,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/utf8-codec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utf8-codec/-/utf8-codec-1.0.0.tgz",
+      "integrity": "sha512-S/QSLezp3qvG4ld5PUfXiH7mCFxLKjSVZRFkB3DOjgwHuJPFDkInAXc/anf7BAbHt/D38ozDzL+QMZ6/7gsI6w==",
+      "license": "MIT"
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
@@ -8439,6 +8837,80 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/w3name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/w3name/-/w3name-1.1.3.tgz",
+      "integrity": "sha512-BqBSvJrD3hOMNriGeV5BJkwNWouLDI7iXu/OdxPUVm3CUqqJ3e0M70ZNGJCV9oNXJt/bscmdyNCHU+RT0drNXw==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@libp2p/crypto": "^5.1.7",
+        "@libp2p/interface": "^2.10.5",
+        "cborg": "^4.2.12",
+        "ipns": "^10.1.2",
+        "multiformats": "^13.3.7",
+        "throttled-queue": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/w3name/node_modules/@libp2p/interface": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-2.11.0.tgz",
+      "integrity": "sha512-0MUFKoXWHTQW3oWIgSHApmYMUKWO/Y02+7Hpyp+n3z+geD4Xo2Rku2gYWmxcq+Pyjkz6Q9YjDWz3Yb2SoV2E8Q==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@multiformats/dns": "^1.0.6",
+        "@multiformats/multiaddr": "^12.4.4",
+        "it-pushable": "^3.2.3",
+        "it-stream-types": "^2.0.2",
+        "main-event": "^1.0.1",
+        "multiformats": "^13.3.6",
+        "progress-events": "^1.0.1",
+        "uint8arraylist": "^2.4.8"
+      }
+    },
+    "node_modules/w3name/node_modules/@multiformats/multiaddr": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.5.1.tgz",
+      "integrity": "sha512-+DDlr9LIRUS8KncI1TX/FfUn8F2dl6BIxJgshS/yFQCNB5IAF0OGzcwB39g5NLE22s4qqDePv0Qof6HdpJ/4aQ==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@multiformats/dns": "^1.0.3",
+        "abort-error": "^1.0.1",
+        "multiformats": "^13.0.0",
+        "uint8-varint": "^2.0.1",
+        "uint8arrays": "^5.0.0"
+      }
+    },
+    "node_modules/w3name/node_modules/multiformats": {
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
+      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/w3name/node_modules/uint8-varint": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.5.tgz",
+      "integrity": "sha512-jeFLbL/x30wBRnWjKE1qVBXeumG46r7XmYkpis955lTQ+blccGKFrOsSMHlxePwYB1pI7L8YPHz1t4jLxEs3nA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^5.0.0"
+      }
+    },
+    "node_modules/w3name/node_modules/uint8arrays": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
+      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -8447,6 +8919,37 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/weald": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/weald/-/weald-1.1.3.tgz",
+      "integrity": "sha512-vMWtNbYuPb58NeG2+0sKA0Een4VMDwzf+3oHqh68buWRSOMUBlUeRb11LhV28czV+DUpJHRykifijZDuS9bInA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "ms": "^4.0.0-nightly.202508271359",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/weald/node_modules/ms": {
+      "version": "4.0.0-nightly.202508271359",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-4.0.0-nightly.202508271359.tgz",
+      "integrity": "sha512-WC/Eo7NzFrOV/RRrTaI0fxKVbNCzEy76j2VqNV8SxDf9D69gSE2Lh0QwYvDlhiYmheBYExAvEAxVf5NoN0cj2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/weald/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lsh-framework",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "description": "Simple, cross-platform encrypted secrets manager with automatic sync, IPFS audit logs, and multi-environment support. Just run lsh sync and start managing your secrets.",
   "main": "dist/cli.js",
   "bin": {
@@ -63,6 +63,7 @@
     "package.json"
   ],
   "dependencies": {
+    "@libp2p/crypto": "^5.1.19",
     "@supabase/supabase-js": "^2.57.4",
     "bcrypt": "^6.0.0",
     "chalk": "^5.3.0",
@@ -80,7 +81,8 @@
     "ora": "^9.0.0",
     "pg": "^8.16.3",
     "proper-lockfile": "^4.1.2",
-    "smol-toml": "^1.3.1"
+    "smol-toml": "^1.3.1",
+    "w3name": "^1.1.3"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -38,6 +38,9 @@ export const ENV_VARS = {
   // Name of the kubo remote pinning service to use for durable sync
   // (configured via `ipfs pin remote service add <name> <endpoint> <key>`).
   LSH_PIN_SERVICE: 'LSH_PIN_SERVICE',
+  // Discovery backend(s) for the key→CID pointer, comma-separated in priority
+  // order. Supported: 'w3name' (durable, hosted), 'ipns' (DHT). Default: 'w3name,ipns'.
+  LSH_DISCOVERY: 'LSH_DISCOVERY',
 
   // Feature flags
   LSH_LOCAL_STORAGE_QUIET: 'LSH_LOCAL_STORAGE_QUIET',
@@ -171,4 +174,6 @@ export const DEFAULTS = {
   IPNS_RESOLVE_TIMEOUT_MS: 30000,        // 30s for DHT lookup
   IPNS_KEY_PREFIX: 'lsh-',
   IPNS_KEY_DERIVATION_CONTEXT: 'lsh-ipns-v1',
+  // Default discovery backends (priority order): durable w3name, then DHT-IPNS fallback.
+  DISCOVERY_BACKENDS: 'w3name,ipns',
 } as const;

--- a/src/lib/discovery-backend.ts
+++ b/src/lib/discovery-backend.ts
@@ -17,6 +17,14 @@ import {
   ensureKeyImported as defaultEnsureKeyImported,
   type IPNSKeyInfo,
 } from './ipns-key-manager.js';
+import {
+  w3namePublish as defaultW3namePublish,
+  w3nameResolve as defaultW3nameResolve,
+} from './w3name-pointer.js';
+import { ENV_VARS, DEFAULTS } from '../constants/config.js';
+import { createLogger } from './logger.js';
+
+const logger = createLogger('Discovery');
 
 export interface DiscoveryPublishParams {
   secretsKey: string;
@@ -88,13 +96,120 @@ export class IpnsDiscoveryBackend implements DiscoveryBackend {
   }
 }
 
+/** Injectable w3name ops (defaults are the real network impls; tests override). */
+export interface W3nameBackendDeps {
+  deriveKeyInfo: (secretsKey: string, repoName: string, env: string) => IPNSKeyInfo;
+  publish: (seed: Buffer, cid: string) => Promise<string>;
+  resolve: (seed: Buffer) => Promise<{ cid: string | null; name: string }>;
+}
+
 /**
- * Select the discovery backend. Currently always IPNS (behaviour-preserving).
- * Phase 2 (issue #194) will read a `LSH_DISCOVERY` setting to choose/compose
- * backends (e.g. w3name primary + ipns fallback).
+ * Durable discovery via w3name (Storacha). Publishes/resolves a signed IPNS
+ * record hosted at name.web3.storage — survives offline nodes, no DHT TTL, no
+ * account. Uses the SAME seed-derived IPNS name as the `ipns` backend.
+ */
+export class W3nameDiscoveryBackend implements DiscoveryBackend {
+  readonly id = 'w3name';
+
+  constructor(
+    private readonly deps: W3nameBackendDeps = {
+      deriveKeyInfo: defaultDeriveKeyInfo,
+      publish: defaultW3namePublish,
+      resolve: defaultW3nameResolve,
+    },
+  ) {}
+
+  async publish({ secretsKey, repoName, env, cid }: DiscoveryPublishParams): Promise<string | null> {
+    const { seed } = this.deps.deriveKeyInfo(secretsKey, repoName, env);
+    return this.deps.publish(seed, cid);
+  }
+
+  async resolve({ secretsKey, repoName, env }: DiscoveryResolveParams): Promise<DiscoveryResolveResult> {
+    const { seed } = this.deps.deriveKeyInfo(secretsKey, repoName, env);
+    return this.deps.resolve(seed);
+  }
+}
+
+/**
+ * Composes backends in priority order. Publish dual-writes to all (best-effort —
+ * a failure in one doesn't block the others). Resolve tries each in order and
+ * returns the first hit, so a durable backend wins but a fallback still works.
+ */
+export class CompositeDiscoveryBackend implements DiscoveryBackend {
+  readonly id: string;
+
+  constructor(private readonly backends: DiscoveryBackend[]) {
+    this.id = backends.map((b) => b.id).join('+');
+  }
+
+  async publish(params: DiscoveryPublishParams): Promise<string | null> {
+    let firstName: string | null = null;
+    for (const backend of this.backends) {
+      try {
+        const name = await backend.publish(params);
+        if (name && !firstName) {
+          firstName = name;
+        }
+      } catch (error) {
+        logger.warn(`Discovery publish via "${backend.id}" failed: ${(error as Error).message}`);
+      }
+    }
+    return firstName;
+  }
+
+  async resolve(params: DiscoveryResolveParams): Promise<DiscoveryResolveResult> {
+    let firstName: string | null = null;
+    for (const backend of this.backends) {
+      try {
+        const result = await backend.resolve(params);
+        if (result.name && !firstName) {
+          firstName = result.name;
+        }
+        if (result.cid) {
+          return result;
+        }
+      } catch (error) {
+        logger.warn(`Discovery resolve via "${backend.id}" failed: ${(error as Error).message}`);
+      }
+    }
+    return { cid: null, name: firstName };
+  }
+}
+
+/** Construct a single backend by id, or null if unknown. */
+function buildBackend(
+  id: string,
+  ipfsSync: Pick<IPFSSync, 'getApiUrl' | 'publishToIPNS' | 'resolveIPNS'>,
+): DiscoveryBackend | null {
+  switch (id) {
+    case 'ipns':
+      return new IpnsDiscoveryBackend(ipfsSync);
+    case 'w3name':
+      return new W3nameDiscoveryBackend();
+    default:
+      logger.warn(`Unknown discovery backend "${id}" — ignoring.`);
+      return null;
+  }
+}
+
+/**
+ * Select discovery backend(s) from `LSH_DISCOVERY` (comma-separated, priority
+ * order; default 'w3name,ipns'). Returns a single backend or a composite.
+ * Falls back to IPNS if the setting resolves to nothing valid.
  */
 export function getDiscoveryBackend(
   ipfsSync: Pick<IPFSSync, 'getApiUrl' | 'publishToIPNS' | 'resolveIPNS'>,
 ): DiscoveryBackend {
-  return new IpnsDiscoveryBackend(ipfsSync);
+  const setting = process.env[ENV_VARS.LSH_DISCOVERY] || DEFAULTS.DISCOVERY_BACKENDS;
+  const backends = setting
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean)
+    .map((id) => buildBackend(id, ipfsSync))
+    .filter((b): b is DiscoveryBackend => b !== null);
+
+  if (backends.length === 0) {
+    return new IpnsDiscoveryBackend(ipfsSync);
+  }
+  return backends.length === 1 ? backends[0] : new CompositeDiscoveryBackend(backends);
 }

--- a/src/lib/ipfs-secrets-storage.ts
+++ b/src/lib/ipfs-secrets-storage.ts
@@ -141,7 +141,7 @@ export class IPFSSecretsStorage {
             metadata.ipns_name = publishedName;
             this.metadata[this.getMetadataKey(gitRepo, environment)] = metadata;
             await this.saveMetadata();
-            logger.info(`   🔗 Published to IPNS: ${publishedName}`);
+            logger.info(`   🔗 Published to ${discovery.id}: ${publishedName}`);
           }
         } catch (error) {
           logger.error(

--- a/src/lib/w3name-pointer.ts
+++ b/src/lib/w3name-pointer.ts
@@ -1,0 +1,79 @@
+/**
+ * w3name pointer ops (issue #194, Phase 2).
+ *
+ * Durable IPNS via Storacha's w3name: publish a signed record mapping the
+ * key-derived IPNS name → `/ipfs/<cid>`, hosted at name.web3.storage (no account,
+ * no auth). The name is IDENTICAL to the one Kubo derives from the same seed
+ * (verified in the Phase-2 spike), so this shares one logical pointer with the
+ * IPNS-over-DHT backend.
+ *
+ * w3name + @libp2p/crypto are heavy ESM deps; they are **lazily imported** inside
+ * the functions so the CLI / unit tests don't load them unless w3name is actually
+ * used.
+ */
+
+import { createLogger } from './logger.js';
+
+const logger = createLogger('W3namePointer');
+
+const PUBLISH_TIMEOUT_MS = 15000;
+const RESOLVE_TIMEOUT_MS = 10000;
+
+function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+  return Promise.race([
+    p,
+    new Promise<T>((_, reject) => {
+      const timer = setTimeout(() => reject(new Error(`w3name ${label} timed out after ${ms}ms`)), ms);
+      timer.unref?.();
+    }),
+  ]);
+}
+
+/** Build a w3name WritableName from a 32-byte ed25519 seed (deterministic). */
+async function writableFromSeed(seed: Buffer) {
+  const [{ generateKeyPairFromSeed, privateKeyToProtobuf }, Name] = await Promise.all([
+    import('@libp2p/crypto/keys'),
+    import('w3name'),
+  ]);
+  const priv = await generateKeyPairFromSeed('Ed25519', new Uint8Array(seed));
+  const name = await Name.from(privateKeyToProtobuf(priv));
+  return { Name, name };
+}
+
+/**
+ * Publish `cid` under the seed-derived w3name pointer. Returns the IPNS name.
+ * Handles IPNS sequencing: increments from the current revision if one exists,
+ * else publishes v0.
+ */
+export async function w3namePublish(seed: Buffer, cid: string): Promise<string> {
+  const { Name, name } = await writableFromSeed(seed);
+  const value = `/ipfs/${cid}`;
+
+  let revision;
+  try {
+    const current = await withTimeout(Name.resolve(name), RESOLVE_TIMEOUT_MS, 'resolve(pre-publish)');
+    revision = await Name.increment(current, value);
+  } catch {
+    // No existing record (or unresolvable) → start a fresh revision.
+    revision = await Name.v0(name, value);
+  }
+
+  await withTimeout(Name.publish(revision, name.key), PUBLISH_TIMEOUT_MS, 'publish');
+  logger.debug(`Published to w3name: ${name.toString()} → ${value}`);
+  return name.toString();
+}
+
+/** Resolve the latest CID for the seed-derived w3name pointer. */
+export async function w3nameResolve(seed: Buffer): Promise<{ cid: string | null; name: string }> {
+  const { Name, name } = await writableFromSeed(seed);
+  const nameStr = name.toString();
+  try {
+    const revision = await withTimeout(Name.resolve(Name.parse(nameStr)), RESOLVE_TIMEOUT_MS, 'resolve');
+    const value = revision.value as string; // "/ipfs/<cid>"
+    const cid = value.startsWith('/ipfs/') ? value.slice('/ipfs/'.length) : null;
+    return { cid, name: nameStr };
+  } catch (error) {
+    logger.debug(`w3name resolve failed for ${nameStr}: ${(error as Error).message}`);
+    return { cid: null, name: nameStr };
+  }
+}

--- a/types/constants/config.d.ts
+++ b/types/constants/config.d.ts
@@ -26,6 +26,7 @@ export declare const ENV_VARS: {
     readonly LSH_SECRETS_KEY: "LSH_SECRETS_KEY";
     readonly LSH_MASTER_KEY: "LSH_MASTER_KEY";
     readonly LSH_PIN_SERVICE: "LSH_PIN_SERVICE";
+    readonly LSH_DISCOVERY: "LSH_DISCOVERY";
     readonly LSH_LOCAL_STORAGE_QUIET: "LSH_LOCAL_STORAGE_QUIET";
     readonly LSH_V1_COMPAT: "LSH_V1_COMPAT";
     readonly DISABLE_IPFS_SYNC: "DISABLE_IPFS_SYNC";
@@ -113,4 +114,5 @@ export declare const DEFAULTS: {
     readonly IPNS_RESOLVE_TIMEOUT_MS: 30000;
     readonly IPNS_KEY_PREFIX: "lsh-";
     readonly IPNS_KEY_DERIVATION_CONTEXT: "lsh-ipns-v1";
+    readonly DISCOVERY_BACKENDS: "w3name,ipns";
 };

--- a/types/lib/discovery-backend.d.ts
+++ b/types/lib/discovery-backend.d.ts
@@ -1,0 +1,95 @@
+/**
+ * Discovery backend seam.
+ *
+ * "Discovery" = mapping a key-derived pointer to the latest content CID
+ * (publish on push, resolve on pull). Today the only backend is IPNS over the
+ * DHT (`IpnsDiscoveryBackend`), which is what LSH has always used — this module
+ * just extracts that behind an interface so additional backends (e.g. a durable
+ * w3name pointer; see issue #194) can be added without touching the storage layer.
+ *
+ * This is a behaviour-preserving refactor: `getDiscoveryBackend()` returns the
+ * IPNS backend, identical to the previous inline logic.
+ */
+import type { IPFSSync } from './ipfs-sync.js';
+import { type IPNSKeyInfo } from './ipns-key-manager.js';
+export interface DiscoveryPublishParams {
+    secretsKey: string;
+    repoName: string;
+    env: string;
+    cid: string;
+}
+export interface DiscoveryResolveParams {
+    secretsKey: string;
+    repoName: string;
+    env: string;
+}
+export interface DiscoveryResolveResult {
+    /** Latest CID for the derived pointer, or null if unresolved. */
+    cid: string | null;
+    /** The pointer name (IPNS name / peer id), or null if the key couldn't be prepared. */
+    name: string | null;
+}
+export interface DiscoveryBackend {
+    /** Stable identifier, e.g. 'ipns'. */
+    readonly id: string;
+    /** Publish `cid` under the key-derived pointer. Returns the pointer name, or null on failure. */
+    publish(params: DiscoveryPublishParams): Promise<string | null>;
+    /** Resolve the latest CID for the key-derived pointer. */
+    resolve(params: DiscoveryResolveParams): Promise<DiscoveryResolveResult>;
+}
+/** Injectable dependencies (defaults are the real implementations; tests override). */
+export interface IpnsBackendDeps {
+    deriveKeyInfo: (secretsKey: string, repoName: string, env: string) => IPNSKeyInfo;
+    ensureKeyImported: (kuboApiUrl: string, keyInfo: IPNSKeyInfo) => Promise<string | null>;
+}
+/**
+ * IPNS-over-DHT discovery: derive a deterministic ed25519 key from the secrets
+ * key, import it into the local Kubo keystore, and publish/resolve via IPNS.
+ */
+export declare class IpnsDiscoveryBackend implements DiscoveryBackend {
+    private readonly ipfsSync;
+    private readonly deps;
+    readonly id = "ipns";
+    constructor(ipfsSync: Pick<IPFSSync, 'getApiUrl' | 'publishToIPNS' | 'resolveIPNS'>, deps?: IpnsBackendDeps);
+    publish({ secretsKey, repoName, env, cid }: DiscoveryPublishParams): Promise<string | null>;
+    resolve({ secretsKey, repoName, env }: DiscoveryResolveParams): Promise<DiscoveryResolveResult>;
+}
+/** Injectable w3name ops (defaults are the real network impls; tests override). */
+export interface W3nameBackendDeps {
+    deriveKeyInfo: (secretsKey: string, repoName: string, env: string) => IPNSKeyInfo;
+    publish: (seed: Buffer, cid: string) => Promise<string>;
+    resolve: (seed: Buffer) => Promise<{
+        cid: string | null;
+        name: string;
+    }>;
+}
+/**
+ * Durable discovery via w3name (Storacha). Publishes/resolves a signed IPNS
+ * record hosted at name.web3.storage — survives offline nodes, no DHT TTL, no
+ * account. Uses the SAME seed-derived IPNS name as the `ipns` backend.
+ */
+export declare class W3nameDiscoveryBackend implements DiscoveryBackend {
+    private readonly deps;
+    readonly id = "w3name";
+    constructor(deps?: W3nameBackendDeps);
+    publish({ secretsKey, repoName, env, cid }: DiscoveryPublishParams): Promise<string | null>;
+    resolve({ secretsKey, repoName, env }: DiscoveryResolveParams): Promise<DiscoveryResolveResult>;
+}
+/**
+ * Composes backends in priority order. Publish dual-writes to all (best-effort —
+ * a failure in one doesn't block the others). Resolve tries each in order and
+ * returns the first hit, so a durable backend wins but a fallback still works.
+ */
+export declare class CompositeDiscoveryBackend implements DiscoveryBackend {
+    private readonly backends;
+    readonly id: string;
+    constructor(backends: DiscoveryBackend[]);
+    publish(params: DiscoveryPublishParams): Promise<string | null>;
+    resolve(params: DiscoveryResolveParams): Promise<DiscoveryResolveResult>;
+}
+/**
+ * Select discovery backend(s) from `LSH_DISCOVERY` (comma-separated, priority
+ * order; default 'w3name,ipns'). Returns a single backend or a composite.
+ * Falls back to IPNS if the setting resolves to nothing valid.
+ */
+export declare function getDiscoveryBackend(ipfsSync: Pick<IPFSSync, 'getApiUrl' | 'publishToIPNS' | 'resolveIPNS'>): DiscoveryBackend;

--- a/types/lib/w3name-pointer.d.ts
+++ b/types/lib/w3name-pointer.d.ts
@@ -1,0 +1,24 @@
+/**
+ * w3name pointer ops (issue #194, Phase 2).
+ *
+ * Durable IPNS via Storacha's w3name: publish a signed record mapping the
+ * key-derived IPNS name → `/ipfs/<cid>`, hosted at name.web3.storage (no account,
+ * no auth). The name is IDENTICAL to the one Kubo derives from the same seed
+ * (verified in the Phase-2 spike), so this shares one logical pointer with the
+ * IPNS-over-DHT backend.
+ *
+ * w3name + @libp2p/crypto are heavy ESM deps; they are **lazily imported** inside
+ * the functions so the CLI / unit tests don't load them unless w3name is actually
+ * used.
+ */
+/**
+ * Publish `cid` under the seed-derived w3name pointer. Returns the IPNS name.
+ * Handles IPNS sequencing: increments from the current revision if one exists,
+ * else publishes v0.
+ */
+export declare function w3namePublish(seed: Buffer, cid: string): Promise<string>;
+/** Resolve the latest CID for the seed-derived w3name pointer. */
+export declare function w3nameResolve(seed: Buffer): Promise<{
+    cid: string | null;
+    name: string;
+}>;


### PR DESCRIPTION
Phase 2 of #194. Fixes the IPNS-over-DHT expiry that caused `lsh pull` → "Could not resolve secrets from network" once the publishing node went offline (~24–48h DHT TTL).

## What
- **`W3nameDiscoveryBackend`** — signed IPNS record via Storacha **w3name** (`name.web3.storage`): durable, **no account/auth**. Same seed-derived IPNS name as Kubo (verified in the Phase-2 spike).
- **`CompositeDiscoveryBackend`** — dual-write on push; resolve in priority order.
- **`getDiscoveryBackend`** reads `LSH_DISCOVERY` (default `w3name,ipns`); resolve order **w3name → ipns → local cache**.
- `w3name-pointer.ts` **lazily** imports `w3name`/`@libp2p/crypto` (not loaded unless used); calls are timeout-bounded + best-effort (a w3name hiccup never blocks push/pull — IPNS fallback covers it).

## Behavior change
Pushes now also publish to w3name by default (free, best-effort). `LSH_DISCOVERY=ipns` restores DHT-only.

## Not in scope (Phase 3)
Discovery durability ≠ byte durability — content still needs a pin (`LSH_PIN_SERVICE`). Bundled default pinner (4EVERLAND) is next.

## Verification
- typecheck/build/lint 0 errors
- 19 discovery unit tests (IPNS + w3name backends, composite dual-write/fallback, `LSH_DISCOVERY` parsing); deps fakes → no network in CI
- full suite 1017 passed; coverage ≥ threshold (discovery-backend.ts 100%)

## Summary by Sourcery

Introduce a pluggable discovery layer with a durable w3name-based backend and make it the default pointer discovery mechanism alongside IPNS.

New Features:
- Add a w3name-based discovery backend that publishes and resolves durable signed IPNS records via name.web3.storage without requiring an account.
- Introduce a composite discovery backend that dual-writes to multiple backends on publish and resolves in priority order.
- Support configuration of discovery backends via the LSH_DISCOVERY environment variable with prioritized, comma-separated values.

Enhancements:
- Refactor discovery selection into a composable backend system with a new getDiscoveryBackend helper that falls back safely to IPNS when misconfigured.
- Improve logging in IPFS secrets storage to reflect the active discovery backend used for publishing.
- Lazily load heavy w3name and @libp2p/crypto dependencies with timeout-bounded, best-effort operations to avoid blocking CLI behavior.

Build:
- Bump package version to 3.6.0 and add @libp2p/crypto and w3name as runtime dependencies.

Documentation:
- Document the new LSH_DISCOVERY environment variable and default discovery behavior in README and CLAUDE.md.
- Add a 3.6.0 release note describing durable discovery via w3name, configuration options, and behavioral changes.

Tests:
- Extend discovery tests to cover the w3name backend, composite backend behavior, and LSH_DISCOVERY parsing and defaults.