### PR TITLE
feat(pinner): bundled 4EVERLAND pinner + discovery docs (Phase 3+4, closes #194)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,8 @@ LSH_SECRETS_KEY=<64-char-hex>   # Required: AES-256 key (from `lsh key`)
 LSH_PIN_SERVICE=<service-name>  # Optional: Kubo remote pinning service for durable sync
 LSH_DISCOVERY=w3name,ipns       # Optional: pointer discovery backends (priority order);
                                 # default durable w3name + DHT-IPNS fallback (issue #194)
+LSH_PIN_TOKEN=<psa-token>       # Optional: auto-register a remote pin service (byte durability);
+LSH_PIN_ENDPOINT=<psa-url>      #   endpoint defaults to 4EVERLAND (https://api.4everland.dev)
 ```
 
 **Discovery layer** (`src/lib/discovery-backend.ts`): the `key→CID` pointer is published/resolved

--- a/README.md
+++ b/README.md
@@ -115,6 +115,21 @@ lsh sync push --env dev
 
 If exactly one remote service is configured, `lsh` uses it automatically and `LSH_PIN_SERVICE` is optional.
 
+### Quickest: bundled pinner (just a token)
+
+Skip the manual `ipfs pin remote service add`. Set **`LSH_PIN_TOKEN`** and `lsh` auto-registers a
+remote pinning service for you on first push — defaulting to **4EVERLAND** (free 5GB, standard
+Pinning Service API):
+
+```bash
+# Get a free accessToken from the 4EVERLAND "4EVER Pin" page (https://4everland.org)
+export LSH_PIN_TOKEN=<your-4everland-accessToken>
+lsh push --env dev        # auto-registers "lsh-pin" → https://api.4everland.dev, then pins
+```
+
+Use a different provider by overriding the endpoint: `export LSH_PIN_ENDPOINT=<psa-endpoint>`.
+(Note: Pinata's pin-by-CID PSA is paid-only; 4EVERLAND and Filebase offer it free.)
+
 ## Installation
 
 ### Prerequisites
@@ -331,6 +346,11 @@ LSH_PIN_SERVICE=<service-name>
 # Default 'w3name,ipns': durable w3name (signed IPNS via name.web3.storage, no
 # account, no DHT TTL) with IPNS-over-DHT fallback. Set 'ipns' for DHT-only.
 LSH_DISCOVERY=w3name,ipns
+
+# Optional - bundled pinner: with a token set, lsh auto-registers a remote pin
+# service so pushed content is durable. Endpoint defaults to 4EVERLAND (free 5GB).
+LSH_PIN_TOKEN=<psa-access-token>
+LSH_PIN_ENDPOINT=https://api.4everland.dev   # override for another PSA provider
 ```
 
 ### Configuration Files

--- a/__tests__/remote-pin-service.test.ts
+++ b/__tests__/remote-pin-service.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Tests for remote pin service selection (issue #194, Phase 3 — bundled pinner).
+ * Pure `chooseRemoteService` logic; the network auto-register
+ * (`ensureDefaultPinService`) is integration-only.
+ */
+import { describe, it, expect } from '@jest/globals';
+import { chooseRemoteService } from '../src/lib/ipfs-sync.js';
+
+const DEFAULT = 'lsh-pin';
+
+describe('chooseRemoteService', () => {
+  it('uses explicit LSH_PIN_SERVICE when it is configured', () => {
+    expect(chooseRemoteService(['pinata', 'lsh-pin'], 'pinata', DEFAULT)).toBe('pinata');
+  });
+
+  it('returns null when explicit LSH_PIN_SERVICE is set but not configured', () => {
+    expect(chooseRemoteService(['lsh-pin'], 'pinata', DEFAULT)).toBeNull();
+  });
+
+  it('explicit takes precedence over the bundled default', () => {
+    expect(chooseRemoteService(['lsh-pin', 'filebase'], 'filebase', DEFAULT)).toBe('filebase');
+  });
+
+  it('prefers the bundled default service when no explicit is set', () => {
+    expect(chooseRemoteService(['lsh-pin', 'other'], undefined, DEFAULT)).toBe(DEFAULT);
+  });
+
+  it('uses the sole configured service when no explicit/default', () => {
+    expect(chooseRemoteService(['only-one'], undefined, DEFAULT)).toBe('only-one');
+  });
+
+  it('returns null when multiple services and no explicit/default (ambiguous)', () => {
+    expect(chooseRemoteService(['a', 'b'], undefined, DEFAULT)).toBeNull();
+  });
+
+  it('returns null when nothing is configured', () => {
+    expect(chooseRemoteService([], undefined, DEFAULT)).toBeNull();
+    expect(chooseRemoteService([], 'pinata', DEFAULT)).toBeNull();
+  });
+});

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -173,6 +173,35 @@ Optional durability: a remote pinning service (e.g. Pinata) can pin the CID so t
 survives when the local Kubo node is offline. `lsh doctor` verifies Kubo is installed and
 running; `lsh init` performs first-time key + Kubo setup.
 
+## Discovery & durability (issue #194)
+
+Two independent concerns, decoupled:
+
+**Discovery** — "given the key, what's the latest CID?" — goes through a `DiscoveryBackend`
+seam (`src/lib/discovery-backend.ts`):
+
+```
+getDiscoveryBackend(ipfsSync)            reads LSH_DISCOVERY (default "w3name,ipns")
+  ├── W3nameDiscoveryBackend             durable signed IPNS via name.web3.storage
+  │     └── w3name-pointer.ts            lazy-imports w3name + @libp2p/crypto
+  ├── IpnsDiscoveryBackend               IPNS over the DHT (fallback / backward compat)
+  │     └── ipns-key-manager.ts          deterministic key derived from LSH_SECRETS_KEY
+  └── CompositeDiscoveryBackend          dual-write on push; resolve w3name → ipns → cache
+```
+
+Both backends derive the **same** ed25519 key from `LSH_SECRETS_KEY` (HMAC), so the w3name name
+and the Kubo IPNS name are identical — one logical pointer. w3name fixes the DHT-IPNS weakness
+(records expire ~24–48h unless an online node republishes); the DHT remains as fallback.
+
+**Availability** — "can the encrypted bytes be fetched?" — is separate. `IPFSSync.addRemotePin`
+pins the CID to a Kubo remote pinning service. `ensureDefaultPinService` auto-registers a bundled
+service when `LSH_PIN_TOKEN` is set (endpoint defaults to 4EVERLAND, override via
+`LSH_PIN_ENDPOINT`); `chooseRemoteService` (pure) selects among configured services
+(explicit `LSH_PIN_SERVICE` → bundled `lsh-pin` → sole service).
+
+> Discovery durability ≠ byte durability: a durable pointer is useless if no node holds the
+> bytes. Use a pin service (`LSH_PIN_TOKEN`) or keep a node online for the content.
+
 ## Security considerations
 
 1. **Secrets encryption** — AES-256 for all stored `.env` content; keys never leave the machine.

--- a/docs/releases/3.7.0.md
+++ b/docs/releases/3.7.0.md
@@ -1,0 +1,45 @@
+# 3.7.0 — Bundled pinner (byte durability) + discovery docs (issue #194)
+
+Completes issue #194. 3.6.0 made the **pointer** durable (w3name); this release makes the
+**bytes** durable with a zero-friction bundled pinner, and documents the discovery layer.
+
+## Bundled pinner (Phase 3)
+
+Set **`LSH_PIN_TOKEN`** and `lsh` auto-registers an IPFS remote pinning service on first push —
+no manual `ipfs pin remote service add`. Endpoint defaults to **4EVERLAND** (free 5GB, standard
+Pinning Service API); override with `LSH_PIN_ENDPOINT` for any PSA provider.
+
+```bash
+export LSH_PIN_TOKEN=<4everland-accessToken>   # from the 4EVER Pin page
+lsh push --env dev   # → registers "lsh-pin" → https://api.4everland.dev, pins the CID
+```
+
+- `IPFSSync.ensureDefaultPinService()` — best-effort auto-register (respects an existing
+  `lsh-pin` and explicit `LSH_PIN_SERVICE`); never throws.
+- `chooseRemoteService()` (pure, unit-tested) — selection precedence: explicit `LSH_PIN_SERVICE`
+  → bundled `lsh-pin` → sole configured service → none.
+
+## Docs (Phase 4)
+
+- `docs/ARCHITECTURE.md`: new **Discovery & durability** section (the `DiscoveryBackend` seam,
+  w3name/ipns/composite, the bundled pinner, and the discovery-≠-availability distinction).
+- README + CLAUDE.md: `LSH_PIN_TOKEN` / `LSH_PIN_ENDPOINT` env vars + a "bundled pinner" quickstart;
+  note that Pinata's pin-by-CID is paid-only while 4EVERLAND/Filebase are free.
+
+## Issue #194 — complete
+
+| Phase | What | Release |
+|---|---|---|
+| 0 | Spike: Ceramic ruled out → w3name | — |
+| 1 | `DiscoveryBackend` seam | 3.6.0 (PR #195) |
+| 2 | w3name backend + composite, `LSH_DISCOVERY` | 3.6.0 (PR #196) |
+| 3 | Bundled 4EVERLAND pinner (`LSH_PIN_TOKEN`) | 3.7.0 |
+| 4 | Docs / ARCHITECTURE | 3.7.0 |
+
+Net: `push`/`pull` from any node with the key, durably — durable pointer (w3name) + durable bytes
+(bundled pin), with IPNS-DHT fallback and full e2e encryption.
+
+## Verification
+- typecheck/build/lint 0 errors
+- new `remote-pin-service.test.ts` — 7/7 (selection precedence)
+- full suite green; discovery + pin selection logic unit-tested without network

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lsh-framework",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lsh-framework",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "license": "MIT",
       "dependencies": {
         "@libp2p/crypto": "^5.1.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lsh-framework",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "Simple, cross-platform encrypted secrets manager with automatic sync, IPFS audit logs, and multi-environment support. Just run lsh sync and start managing your secrets.",
   "main": "dist/cli.js",
   "bin": {

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -41,6 +41,12 @@ export const ENV_VARS = {
   // Discovery backend(s) for the key→CID pointer, comma-separated in priority
   // order. Supported: 'w3name' (durable, hosted), 'ipns' (DHT). Default: 'w3name,ipns'.
   LSH_DISCOVERY: 'LSH_DISCOVERY',
+  // Access token for a bundled IPFS remote pinning service. When set (and no
+  // remote pin service is already configured), lsh auto-registers one so pushed
+  // content is durably pinned. Endpoint defaults to 4EVERLAND (free 5GB).
+  LSH_PIN_TOKEN: 'LSH_PIN_TOKEN',
+  // Override the PSA endpoint used with LSH_PIN_TOKEN (any IPFS Pinning Service).
+  LSH_PIN_ENDPOINT: 'LSH_PIN_ENDPOINT',
 
   // Feature flags
   LSH_LOCAL_STORAGE_QUIET: 'LSH_LOCAL_STORAGE_QUIET',
@@ -176,4 +182,8 @@ export const DEFAULTS = {
   IPNS_KEY_DERIVATION_CONTEXT: 'lsh-ipns-v1',
   // Default discovery backends (priority order): durable w3name, then DHT-IPNS fallback.
   DISCOVERY_BACKENDS: 'w3name,ipns',
+  // Bundled remote pinning service (used with LSH_PIN_TOKEN). 4EVERLAND free tier (5GB),
+  // standard IPFS Pinning Service API. Override the endpoint via LSH_PIN_ENDPOINT.
+  DEFAULT_PIN_ENDPOINT: 'https://api.4everland.dev',
+  DEFAULT_PIN_SERVICE_NAME: 'lsh-pin',
 } as const;

--- a/src/lib/ipfs-sync.ts
+++ b/src/lib/ipfs-sync.ts
@@ -16,7 +16,28 @@ import * as path from 'path';
 import * as os from 'os';
 import { createLogger } from './logger.js';
 import { extractErrorMessage } from './lsh-error.js';
-import { ENV_VARS } from '../constants/config.js';
+import { ENV_VARS, DEFAULTS } from '../constants/config.js';
+
+/**
+ * Pure helper: choose which configured remote pinning service to use.
+ * - explicit `LSH_PIN_SERVICE` wins, but only if it's actually configured;
+ * - else the bundled default service (`lsh-pin`) if present;
+ * - else the sole configured service;
+ * - else null (none / ambiguous).
+ */
+export function chooseRemoteService(
+  services: string[],
+  explicit: string | undefined,
+  defaultName: string,
+): string | null {
+  if (explicit) {
+    return services.includes(explicit) ? explicit : null;
+  }
+  if (services.includes(defaultName)) {
+    return defaultName;
+  }
+  return services.length === 1 ? services[0] : null;
+}
 
 const logger = createLogger('IPFSSync');
 
@@ -428,12 +449,45 @@ export class IPFSSync {
    * - Returns null when nothing is configured or the choice is ambiguous.
    */
   async resolveRemoteService(): Promise<string | null> {
+    await this.ensureDefaultPinService();
     const services = await this.listRemoteServices();
-    const explicit = process.env[ENV_VARS.LSH_PIN_SERVICE];
-    if (explicit) {
-      return services.includes(explicit) ? explicit : null;
+    return chooseRemoteService(
+      services,
+      process.env[ENV_VARS.LSH_PIN_SERVICE],
+      DEFAULTS.DEFAULT_PIN_SERVICE_NAME,
+    );
+  }
+
+  /**
+   * Bundled pinner: when LSH_PIN_TOKEN is set and no remote pin service named
+   * `lsh-pin` is registered yet, auto-register one (endpoint defaults to
+   * 4EVERLAND, override via LSH_PIN_ENDPOINT). Lets users get durable pinning
+   * with just a token — no manual `ipfs pin remote service add`. Best-effort;
+   * never throws. Respects an existing service of the same name and the
+   * explicit LSH_PIN_SERVICE (handled by chooseRemoteService).
+   */
+  async ensureDefaultPinService(): Promise<void> {
+    const token = process.env[ENV_VARS.LSH_PIN_TOKEN];
+    if (!token) return;
+    const name = DEFAULTS.DEFAULT_PIN_SERVICE_NAME;
+    try {
+      const existing = await this.listRemoteServices();
+      if (existing.includes(name)) return;
+      const endpoint = process.env[ENV_VARS.LSH_PIN_ENDPOINT] || DEFAULTS.DEFAULT_PIN_ENDPOINT;
+      const url =
+        `${this.LOCAL_IPFS_API}/pin/remote/service/add` +
+        `?arg=${encodeURIComponent(name)}` +
+        `&arg=${encodeURIComponent(endpoint)}` +
+        `&arg=${encodeURIComponent(token)}`;
+      const response = await fetch(url, { method: 'POST', signal: AbortSignal.timeout(10000) });
+      if (response.ok) {
+        logger.info(`📌 Registered bundled pin service "${name}" → ${endpoint}`);
+      } else {
+        logger.warn(`Could not register pin service "${name}": ${await response.text()}`);
+      }
+    } catch (error) {
+      logger.warn(`Pin service registration error: ${extractErrorMessage(error)}`);
     }
-    return services.length === 1 ? services[0] : null;
   }
 
   /**

--- a/types/constants/config.d.ts
+++ b/types/constants/config.d.ts
@@ -27,6 +27,8 @@ export declare const ENV_VARS: {
     readonly LSH_MASTER_KEY: "LSH_MASTER_KEY";
     readonly LSH_PIN_SERVICE: "LSH_PIN_SERVICE";
     readonly LSH_DISCOVERY: "LSH_DISCOVERY";
+    readonly LSH_PIN_TOKEN: "LSH_PIN_TOKEN";
+    readonly LSH_PIN_ENDPOINT: "LSH_PIN_ENDPOINT";
     readonly LSH_LOCAL_STORAGE_QUIET: "LSH_LOCAL_STORAGE_QUIET";
     readonly LSH_V1_COMPAT: "LSH_V1_COMPAT";
     readonly DISABLE_IPFS_SYNC: "DISABLE_IPFS_SYNC";
@@ -115,4 +117,6 @@ export declare const DEFAULTS: {
     readonly IPNS_KEY_PREFIX: "lsh-";
     readonly IPNS_KEY_DERIVATION_CONTEXT: "lsh-ipns-v1";
     readonly DISCOVERY_BACKENDS: "w3name,ipns";
+    readonly DEFAULT_PIN_ENDPOINT: "https://api.4everland.dev";
+    readonly DEFAULT_PIN_SERVICE_NAME: "lsh-pin";
 };

--- a/types/lib/ipfs-sync.d.ts
+++ b/types/lib/ipfs-sync.d.ts
@@ -9,6 +9,14 @@
  * - Direct CID sharing: Share CIDs with teammates
  * - Public gateways: Retrieve from ipfs.io, dweb.link, cloudflare-ipfs
  */
+/**
+ * Pure helper: choose which configured remote pinning service to use.
+ * - explicit `LSH_PIN_SERVICE` wins, but only if it's actually configured;
+ * - else the bundled default service (`lsh-pin`) if present;
+ * - else the sole configured service;
+ * - else null (none / ambiguous).
+ */
+export declare function chooseRemoteService(services: string[], explicit: string | undefined, defaultName: string): string | null;
 export interface SyncHistoryEntry {
     cid: string;
     filename: string;
@@ -111,6 +119,15 @@ export declare class IPFSSync {
      * - Returns null when nothing is configured or the choice is ambiguous.
      */
     resolveRemoteService(): Promise<string | null>;
+    /**
+     * Bundled pinner: when LSH_PIN_TOKEN is set and no remote pin service named
+     * `lsh-pin` is registered yet, auto-register one (endpoint defaults to
+     * 4EVERLAND, override via LSH_PIN_ENDPOINT). Lets users get durable pinning
+     * with just a token — no manual `ipfs pin remote service add`. Best-effort;
+     * never throws. Respects an existing service of the same name and the
+     * explicit LSH_PIN_SERVICE (handled by chooseRemoteService).
+     */
+    ensureDefaultPinService(): Promise<void>;
     /**
      * Pin a CID to a configured remote pinning service so the content survives
      * this machine going offline. This is what makes "pull anywhere, anytime"


### PR DESCRIPTION
Phases 3 & 4 of #194 — **completes the issue**.

## Phase 3 — bundled pinner (byte durability)
Set **`LSH_PIN_TOKEN`** → `lsh` auto-registers a remote pin service on first push (no manual `ipfs pin remote service add`). Endpoint defaults to **4EVERLAND** (free 5GB, standard PSA); override via `LSH_PIN_ENDPOINT`.
- `ensureDefaultPinService()` — best-effort auto-register; respects existing `lsh-pin` + explicit `LSH_PIN_SERVICE`; never throws.
- `chooseRemoteService()` — pure, unit-tested precedence (explicit → bundled `lsh-pin` → sole → none).

## Phase 4 — docs
- `ARCHITECTURE.md`: new **Discovery & durability** section (the seam, w3name/ipns/composite, bundled pinner, discovery≠availability).
- README + CLAUDE.md: `LSH_PIN_TOKEN`/`LSH_PIN_ENDPOINT` + quickstart; Pinata paid-PSA caveat.

## Closes #194
Pointer durability (w3name, 3.6.0) + byte durability (bundled pin, this PR) = push/pull from any node with the key, durably, with IPNS-DHT fallback and e2e encryption.

## Verification
typecheck/build/lint 0 errors · new `remote-pin-service.test.ts` 7/7 · full suite 1024 passed.

Closes #194

## Summary by Sourcery

Add a bundled remote pinning service for byte durability and document the discovery and durability model, completing issue #194.

New Features:
- Automatically register a default remote pinning service when LSH_PIN_TOKEN is set, defaulting to a 4EVERLAND-backed service configurable via environment variables.
- Introduce a pure helper to deterministically choose which remote pinning service to use based on explicit configuration and bundled defaults.

Enhancements:
- Clarify the architecture with a new Discovery & durability section explaining pointer discovery, availability, and the role of bundled pinning.
- Update configuration defaults and environment variables to support the bundled pinner, including default pin service name and endpoint.
- Bump the package version to 3.7.0 and add a dedicated release notes document describing the new durability features.

Documentation:
- Expand README and CLAUDE.md with quickstart instructions and configuration details for the bundled pinner and related environment variables.

Tests:
- Add unit tests for remote pinning service selection logic to ensure correct precedence and behavior in edge cases.