### PR TITLE
feat(shell-init): auto-wire `lsh load` into shell rc files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ lsh                                # If globally linked (npm link)
 ```
 
 Real top-level commands: `init`, `doctor`, `config`, `sync`, `sync-history`, `ipfs`, `migrate`,
-`context`, `self`, `completion`, plus the secrets verbs `push`, `pull`, `get`, `set`, `list`,
+`context`, `self`, `completion`, `shell-init`, plus the secrets verbs `push`, `pull`, `get`, `set`, `list`,
 `env`, `key`, `create`, `load`, `status`, `info`, `delete`, `clear`, `cp`. Verify with
 `node dist/cli.js --help` — there is **no** `daemon`, `cron`, `api`, `supabase`, or `storacha`
 command.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ printenv | lsh set    # Batch import from stdin
 # Multi-environment
 lsh push --env prod
 lsh pull --env staging
+
+# Load secrets into your shell
+lsh load              # print `export` lines (use with: eval "$(lsh load)")
+lsh shell-init        # wire `lsh load` into ~/.zshrc or ~/.bashrc automatically
 ```
 
 ## How It Works
@@ -248,6 +252,23 @@ lsh list --format export  # Shell export statements
 # Load into current shell
 eval "$(lsh list --format export)"
 ```
+
+### Auto-load in every shell
+
+Rather than pasting an `eval` line into your rc file by hand, let lsh wire it up
+(homebrew-style — idempotent, with a one-time backup):
+
+```bash
+lsh shell-init                 # detect shell, append managed block to ~/.zshrc or ~/.bashrc
+lsh shell-init zsh             # force a shell
+lsh shell-init --file ~/.zshrc # target a specific rc file
+lsh shell-init --dry-run       # show what would be added, write nothing
+lsh shell-init --print         # just print the block (pipe it yourself)
+lsh shell-init --uninstall     # remove the managed block
+```
+
+The block runs `eval "$(lsh load --global --quiet)"`, which loads `$HOME/.env`
+via an **absolute** path — so it never depends on the current directory.
 
 ## Security
 

--- a/__tests__/shell-init.test.ts
+++ b/__tests__/shell-init.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for the `lsh shell-init` pure logic (src/lib/shell-init.ts).
+ * Pure string/path transforms — no fs, no shell, no network required.
+ */
+import { describe, it, expect } from '@jest/globals';
+import {
+  detectShell,
+  rcFileForShell,
+  buildBlock,
+  hasBlock,
+  upsertBlock,
+  removeBlock,
+} from '../src/lib/shell-init.js';
+import { SHELL_INIT } from '../src/constants/index.js';
+
+describe('detectShell', () => {
+  it('detects zsh from a $SHELL path', () => {
+    expect(detectShell('/bin/zsh')).toBe('zsh');
+  });
+
+  it('detects bash from a $SHELL path', () => {
+    expect(detectShell('/usr/bin/bash')).toBe('bash');
+  });
+
+  it('returns undefined for unknown or missing shells', () => {
+    expect(detectShell('/usr/bin/fish')).toBeUndefined();
+    expect(detectShell('')).toBeUndefined();
+    expect(detectShell(undefined)).toBeUndefined();
+  });
+});
+
+describe('rcFileForShell', () => {
+  it('maps zsh to ~/.zshrc and bash to ~/.bashrc', () => {
+    expect(rcFileForShell('zsh', '/home/u')).toBe('/home/u/.zshrc');
+    expect(rcFileForShell('bash', '/home/u')).toBe('/home/u/.bashrc');
+  });
+});
+
+describe('buildBlock', () => {
+  it('wraps the load line between start and end markers', () => {
+    const block = buildBlock();
+    expect(block.startsWith(SHELL_INIT.MARKER_START)).toBe(true);
+    expect(block.trimEnd().endsWith(SHELL_INIT.MARKER_END)).toBe(true);
+    expect(block).toContain(SHELL_INIT.LOAD_LINE);
+  });
+});
+
+describe('hasBlock', () => {
+  it('is false for content without the marker and true once inserted', () => {
+    expect(hasBlock('export FOO=1\n')).toBe(false);
+    expect(hasBlock(upsertBlock('export FOO=1\n'))).toBe(true);
+  });
+});
+
+describe('upsertBlock', () => {
+  it('appends the block separated by a blank line from prior content', () => {
+    const out = upsertBlock('export FOO=1\n');
+    expect(out).toBe(`export FOO=1\n\n${buildBlock()}\n`);
+  });
+
+  it('handles empty content without a leading blank line', () => {
+    expect(upsertBlock('')).toBe(`${buildBlock()}\n`);
+  });
+
+  it('is idempotent — re-running does not duplicate the block', () => {
+    const once = upsertBlock('export FOO=1\n');
+    const twice = upsertBlock(once);
+    expect(twice).toBe(once);
+    expect(twice.match(new RegExp(SHELL_INIT.MARKER_START, 'g'))).toHaveLength(1);
+  });
+
+  it('upgrades an existing block in place when the line changes', () => {
+    const old = `before\n${buildBlock('eval "$(lsh load)"')}\nafter\n`;
+    const out = upsertBlock(old, buildBlock('eval "$(lsh load --global --quiet)"'));
+    expect(out).toContain('eval "$(lsh load --global --quiet)"');
+    expect(out).not.toContain('eval "$(lsh load)"\n');
+    expect(out).toContain('before');
+    expect(out).toContain('after');
+  });
+});
+
+describe('removeBlock', () => {
+  it('removes the managed block and its surrounding blank line', () => {
+    const withBlock = upsertBlock('export FOO=1\n');
+    expect(removeBlock(withBlock)).toBe('export FOO=1\n');
+  });
+
+  it('is a no-op when no managed block is present', () => {
+    expect(removeBlock('export FOO=1\n')).toBe('export FOO=1\n');
+  });
+
+  it('survives an install/uninstall round-trip without drift', () => {
+    const original = 'export FOO=1\n';
+    expect(removeBlock(upsertBlock(original))).toBe(original);
+  });
+});

--- a/docs/releases/3.7.1.md
+++ b/docs/releases/3.7.1.md
@@ -1,0 +1,58 @@
+# v3.7.1
+
+## `lsh shell-init` — auto-wire `lsh load` into your shell
+
+New command that appends a managed block to your shell rc file so secrets load
+into every new shell automatically — homebrew-style, instead of pasting an
+`eval` line by hand.
+
+```bash
+lsh shell-init                 # detect shell, append block to ~/.zshrc or ~/.bashrc
+lsh shell-init zsh|bash        # force a shell
+lsh shell-init --file <path>   # target a specific rc file
+lsh shell-init --dry-run       # preview, write nothing
+lsh shell-init --print         # print the block only (pipe it yourself)
+lsh shell-init --uninstall     # remove the managed block
+```
+
+The block it writes:
+
+```bash
+# >>> lsh shell-init >>>
+eval "$(lsh load --global --quiet)"
+# <<< lsh shell-init <<<
+```
+
+### Behavior
+
+- **Idempotent** — re-running makes no change once present; if the load line
+  changes in a future release, the block is upgraded in place.
+- **Safe** — backs up an existing rc file to `<rc>.lsh-backup` once before the
+  first modification; `--uninstall` removes only the marked block and leaves the
+  rest (and surrounding whitespace) intact.
+- **cwd-proof** — the block loads `$HOME/.env` via the **absolute**-path
+  `lsh load --global`, which never calls `process.cwd()`. A bare cwd-relative
+  `eval "$(lsh load)"` in an rc file crashes with `ENOENT … uv_cwd` when the
+  shell's working directory has been deleted/remounted; `--global` avoids it.
+
+### Before / After
+
+```
+Before                              After
+------                              -----
+npm i -g lsh-framework              npm i -g lsh-framework
+  (no postinstall hint)             lsh shell-init
+paste eval line into ~/.zshrc         → detects shell
+yourself, hope quoting is right       → backs up rc once
+                                      → appends marker-guarded block
+                                      → idempotent + uninstallable
+```
+
+## Implementation
+
+- `src/lib/shell-init.ts` — pure, unit-tested logic (shell detection, rc path,
+  marker block build/insert/remove). No fs/process state.
+- `src/commands/shell-init.ts` — thin I/O + Commander layer.
+- `__tests__/shell-init.test.ts` — 13 tests covering detection, idempotency,
+  in-place upgrade, and install/uninstall round-trip.
+- Strings centralized in `src/constants/commands.ts` (`SHELL_INIT`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lsh-framework",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lsh-framework",
-      "version": "3.7.0",
+      "version": "3.7.1",
       "license": "MIT",
       "dependencies": {
         "@libp2p/crypto": "^5.1.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lsh-framework",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "Simple, cross-platform encrypted secrets manager with automatic sync, IPFS audit logs, and multi-environment support. Just run lsh sync and start managing your secrets.",
   "main": "dist/cli.js",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import selfCommand from './commands/self.js';
 import { registerInitCommands } from './commands/init.js';
 import { registerDoctorCommands } from './commands/doctor.js';
 import { registerCompletionCommands } from './commands/completion.js';
+import { registerShellInitCommand } from './commands/shell-init.js';
 import { registerConfigCommands } from './commands/config.js';
 import { registerSyncHistoryCommands } from './commands/sync-history.js';
 import { registerSyncCommands } from './commands/sync.js';
@@ -168,6 +169,9 @@ function findSimilarCommands(input: string, validCommands: string[]): string[] {
 
   // Shell completion
   registerCompletionCommands(program);
+
+  // Shell rc wire-up (eval "$(lsh load)")
+  registerShellInitCommand(program);
 
   // Self-management commands
   program.addCommand(selfCommand);

--- a/src/commands/shell-init.ts
+++ b/src/commands/shell-init.ts
@@ -1,0 +1,128 @@
+/**
+ * `lsh shell-init` — wire `lsh load` into the user's shell rc file.
+ *
+ * Homebrew-style: detects the shell, appends a marker-guarded block that runs
+ * `eval "$(lsh load --global --quiet)"` on every new shell, idempotently and
+ * with a one-time backup. All real logic lives in src/lib/shell-init.ts (pure,
+ * unit-tested); this file is just argument parsing + filesystem I/O.
+ */
+
+import { Command } from 'commander';
+import * as fs from 'fs';
+import * as os from 'os';
+import {
+  detectShell,
+  rcFileForShell,
+  buildBlock,
+  hasBlock,
+  upsertBlock,
+  removeBlock,
+  type ShellName,
+} from '../lib/shell-init.js';
+import { SHELL_INIT } from '../constants/index.js';
+import { ENV_VARS } from '../constants/config.js';
+import { extractErrorMessage } from '../lib/lsh-error.js';
+
+const SUPPORTED: ShellName[] = ['zsh', 'bash'];
+
+function resolveShell(arg?: string): ShellName | undefined {
+  if (arg) {
+    const lower = arg.toLowerCase();
+    return SUPPORTED.includes(lower as ShellName) ? (lower as ShellName) : undefined;
+  }
+  return detectShell(process.env[ENV_VARS.SHELL]);
+}
+
+function homeDir(): string {
+  return process.env[ENV_VARS.HOME] || os.homedir();
+}
+
+export function registerShellInitCommand(program: Command): void {
+  program
+    .command('shell-init [shell]')
+    .description('Wire `lsh load` into your shell rc file (zsh or bash)')
+    .option('-f, --file <path>', 'Target rc file (overrides auto-detection)')
+    .option('--print', 'Print the block to stdout instead of writing any file')
+    .option('--dry-run', 'Show the target file and block without writing')
+    .option('--uninstall', 'Remove the lsh-managed block from the rc file')
+    .action((shellArg: string | undefined, options) => {
+      try {
+        const block = buildBlock();
+
+        // --print: emit the block, do nothing else. Pipe it yourself.
+        if (options.print) {
+          console.log(block);
+          return;
+        }
+
+        // Resolve the target rc file.
+        let rcPath: string;
+        if (options.file) {
+          rcPath = options.file;
+        } else {
+          const shell = resolveShell(shellArg);
+          if (!shell) {
+            console.error('❌ Could not determine your shell.');
+            console.error('💡 Pass one explicitly: lsh shell-init zsh  (or bash)');
+            console.error('💡 Or target a file directly: lsh shell-init --file ~/.zshrc');
+            process.exit(1);
+            return;
+          }
+          rcPath = rcFileForShell(shell, homeDir());
+        }
+
+        const existing = fs.existsSync(rcPath) ? fs.readFileSync(rcPath, 'utf8') : '';
+
+        // --uninstall: strip the managed block.
+        if (options.uninstall) {
+          if (!hasBlock(existing)) {
+            console.log(`ℹ️  No lsh block found in ${rcPath} — nothing to remove.`);
+            return;
+          }
+          if (options.dryRun) {
+            console.log(`Would remove the lsh-managed block from ${rcPath}`);
+            return;
+          }
+          fs.writeFileSync(rcPath, removeBlock(existing), 'utf8');
+          console.log(`✅ Removed lsh block from ${rcPath}`);
+          console.log('💡 Restart your shell to apply.');
+          return;
+        }
+
+        const alreadyPresent = hasBlock(existing);
+        const updated = upsertBlock(existing, block);
+
+        // --dry-run: report intent only.
+        if (options.dryRun) {
+          console.log(`Target: ${rcPath}`);
+          console.log(alreadyPresent ? '(would update existing lsh block)\n' : '(would append)\n');
+          console.log(block);
+          return;
+        }
+
+        if (alreadyPresent && updated === existing) {
+          console.log(`ℹ️  ${rcPath} already wired up — no change.`);
+          return;
+        }
+
+        // Back up an existing rc file once before the first modification.
+        if (existing && !alreadyPresent) {
+          const backup = `${rcPath}.lsh-backup`;
+          if (!fs.existsSync(backup)) {
+            fs.writeFileSync(backup, existing, 'utf8');
+            console.log(`📦 Backed up ${rcPath} → ${backup}`);
+          }
+        }
+
+        fs.writeFileSync(rcPath, updated, 'utf8');
+        console.log(`✅ ${alreadyPresent ? 'Updated' : 'Added'} lsh block in ${rcPath}`);
+        console.log(`   ${SHELL_INIT.LOAD_LINE}`);
+        console.log('💡 Restart your shell (or `source` the file) to apply.');
+      } catch (error) {
+        console.error('❌ shell-init failed:', extractErrorMessage(error));
+        process.exit(1);
+      }
+    });
+}
+
+export default registerShellInitCommand;

--- a/src/constants/commands.ts
+++ b/src/constants/commands.ts
@@ -70,3 +70,13 @@ export const PLATFORMS = {
   GITLAB: 'gitlab',
   JENKINS: 'jenkins',
 } as const;
+
+// `lsh shell-init` — managed block injected into the user's shell rc file so
+// secrets load into every shell automatically (homebrew-style wire-up).
+export const SHELL_INIT = {
+  MARKER_START: '# >>> lsh shell-init >>>',
+  MARKER_END: '# <<< lsh shell-init <<<',
+  // Absolute ($HOME/.env) path → never calls process.cwd(), so it can't hit
+  // the `uv_cwd` crash a cwd-relative `lsh load` does on a stale directory.
+  LOAD_LINE: 'eval "$(lsh load --global --quiet)"',
+} as const;

--- a/src/lib/shell-init.ts
+++ b/src/lib/shell-init.ts
@@ -1,0 +1,87 @@
+/**
+ * shell-init pure logic
+ *
+ * Powers `lsh shell-init`, which wires `lsh load` into the user's shell rc file
+ * (homebrew-style) so secrets load into every new shell automatically.
+ *
+ * Everything here is a pure string/path transform — no fs, no process state —
+ * so the command layer (src/commands/shell-init.ts) stays a thin I/O shell and
+ * all the real behavior is unit-testable without a shell or filesystem.
+ */
+
+import * as path from 'path';
+import { SHELL_INIT } from '../constants/index.js';
+
+export type ShellName = 'zsh' | 'bash';
+
+/**
+ * Identify the shell from a `$SHELL`-style path (e.g. `/bin/zsh`).
+ * Returns undefined for anything we don't manage an rc file for.
+ */
+export function detectShell(shellPath?: string): ShellName | undefined {
+  if (!shellPath) return undefined;
+  const base = path.basename(shellPath);
+  if (base.includes('zsh')) return 'zsh';
+  if (base.includes('bash')) return 'bash';
+  return undefined;
+}
+
+/** Absolute path to the rc file lsh manages for a given shell. */
+export function rcFileForShell(shell: ShellName, homeDir: string): string {
+  return path.join(homeDir, shell === 'zsh' ? '.zshrc' : '.bashrc');
+}
+
+/** The marker-wrapped block lsh owns inside the rc file. */
+export function buildBlock(line: string = SHELL_INIT.LOAD_LINE): string {
+  return `${SHELL_INIT.MARKER_START}\n${line}\n${SHELL_INIT.MARKER_END}`;
+}
+
+/** Does the rc content already contain an lsh-managed block? */
+export function hasBlock(content: string): boolean {
+  return content.includes(SHELL_INIT.MARKER_START);
+}
+
+/**
+ * Matches the managed block. The `[\s\S]*?` is non-greedy so adjacent content
+ * isn't swallowed if a malformed file somehow has two start markers.
+ */
+function blockRegex(): RegExp {
+  const start = escapeRegExp(SHELL_INIT.MARKER_START);
+  const end = escapeRegExp(SHELL_INIT.MARKER_END);
+  return new RegExp(`${start}[\\s\\S]*?${end}`);
+}
+
+/**
+ * Idempotently insert the block. If a managed block already exists it is
+ * replaced in place (so re-running after the line changes upgrades it); if it
+ * doesn't exist it's appended, separated from prior content by a blank line.
+ */
+export function upsertBlock(content: string, block: string = buildBlock()): string {
+  if (hasBlock(content)) {
+    return content.replace(blockRegex(), block);
+  }
+  if (content.length === 0) {
+    return `${block}\n`;
+  }
+  const sep = content.endsWith('\n\n') ? '' : content.endsWith('\n') ? '\n' : '\n\n';
+  return `${content}${sep}${block}\n`;
+}
+
+/**
+ * Remove the managed block, cleaning up the surrounding blank line(s) it was
+ * inserted with so repeated install/uninstall cycles don't accumulate gaps.
+ */
+export function removeBlock(content: string): string {
+  const start = escapeRegExp(SHELL_INIT.MARKER_START);
+  const end = escapeRegExp(SHELL_INIT.MARKER_END);
+  // Eat the single blank-line separator upsert added + the block + its
+  // trailing newline, leaving the prior content's own terminator intact.
+  const withSurrounding = new RegExp(`\\n?${start}[\\s\\S]*?${end}\\n?`);
+  return content.replace(withSurrounding, '');
+}
+
+function escapeRegExp(s: string): string {
+  // '\\$&' is the regex back-reference for "the matched char", not a UI string.
+  // eslint-disable-next-line lsh/no-hardcoded-strings
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/types/commands/shell-init.d.ts
+++ b/types/commands/shell-init.d.ts
@@ -1,0 +1,11 @@
+/**
+ * `lsh shell-init` — wire `lsh load` into the user's shell rc file.
+ *
+ * Homebrew-style: detects the shell, appends a marker-guarded block that runs
+ * `eval "$(lsh load --global --quiet)"` on every new shell, idempotently and
+ * with a one-time backup. All real logic lives in src/lib/shell-init.ts (pure,
+ * unit-tested); this file is just argument parsing + filesystem I/O.
+ */
+import { Command } from 'commander';
+export declare function registerShellInitCommand(program: Command): void;
+export default registerShellInitCommand;

--- a/types/constants/commands.d.ts
+++ b/types/constants/commands.d.ts
@@ -60,3 +60,8 @@ export declare const PLATFORMS: {
     readonly GITLAB: "gitlab";
     readonly JENKINS: "jenkins";
 };
+export declare const SHELL_INIT: {
+    readonly MARKER_START: "# >>> lsh shell-init >>>";
+    readonly MARKER_END: "# <<< lsh shell-init <<<";
+    readonly LOAD_LINE: "eval \"$(lsh load --global --quiet)\"";
+};

--- a/types/lib/shell-init.d.ts
+++ b/types/lib/shell-init.d.ts
@@ -1,0 +1,33 @@
+/**
+ * shell-init pure logic
+ *
+ * Powers `lsh shell-init`, which wires `lsh load` into the user's shell rc file
+ * (homebrew-style) so secrets load into every new shell automatically.
+ *
+ * Everything here is a pure string/path transform — no fs, no process state —
+ * so the command layer (src/commands/shell-init.ts) stays a thin I/O shell and
+ * all the real behavior is unit-testable without a shell or filesystem.
+ */
+export type ShellName = 'zsh' | 'bash';
+/**
+ * Identify the shell from a `$SHELL`-style path (e.g. `/bin/zsh`).
+ * Returns undefined for anything we don't manage an rc file for.
+ */
+export declare function detectShell(shellPath?: string): ShellName | undefined;
+/** Absolute path to the rc file lsh manages for a given shell. */
+export declare function rcFileForShell(shell: ShellName, homeDir: string): string;
+/** The marker-wrapped block lsh owns inside the rc file. */
+export declare function buildBlock(line?: string): string;
+/** Does the rc content already contain an lsh-managed block? */
+export declare function hasBlock(content: string): boolean;
+/**
+ * Idempotently insert the block. If a managed block already exists it is
+ * replaced in place (so re-running after the line changes upgrades it); if it
+ * doesn't exist it's appended, separated from prior content by a blank line.
+ */
+export declare function upsertBlock(content: string, block?: string): string;
+/**
+ * Remove the managed block, cleaning up the surrounding blank line(s) it was
+ * inserted with so repeated install/uninstall cycles don't accumulate gaps.
+ */
+export declare function removeBlock(content: string): string;


### PR DESCRIPTION
## Summary

Adds `lsh shell-init` — wires `lsh load` into the user's shell rc file
(homebrew-style) so secrets load into every new shell automatically, instead of
hand-pasting an `eval` line.

```bash
lsh shell-init                 # detect shell, append block to ~/.zshrc or ~/.bashrc
lsh shell-init zsh|bash        # force a shell
lsh shell-init --file <path>   # target a specific rc file
lsh shell-init --dry-run       # preview, write nothing
lsh shell-init --print         # print the block only
lsh shell-init --uninstall     # remove the managed block
```

Block written:

```bash
# >>> lsh shell-init >>>
eval "$(lsh load --global --quiet)"
# <<< lsh shell-init <<<
```

## Before / After

```mermaid
flowchart LR
  A[npm i -g lsh-framework] --> B[no postinstall hint]
  B --> C[user hand-pastes eval into ~/.zshrc]
  C --> D[quoting/cwd footguns]
```

```mermaid
flowchart LR
  A[npm i -g lsh-framework] --> B[lsh shell-init]
  B --> C[detect shell + back up rc once]
  C --> D[append marker-guarded block]
  D --> E[idempotent + uninstallable + cwd-proof]
```

## Behavior

- **Idempotent** — re-running is a no-op once present; upgrades the block in
  place if the load line changes in a future release.
- **Safe** — one-time backup to `<rc>.lsh-backup`; `--uninstall` removes only the
  marked block and surrounding separator, nothing else.
- **cwd-proof** — uses `lsh load --global` (absolute `$HOME/.env`), which never
  calls `process.cwd()`, avoiding the `ENOENT … uv_cwd` crash a bare
  cwd-relative `eval "$(lsh load)"` in an rc file hits on a stale directory.

## Tests

- `__tests__/shell-init.test.ts` — 13 unit tests on pure logic (shell detection,
  rc path mapping, idempotency, in-place upgrade, install/uninstall round-trip).
- Full suite: 1095 passing, 0 regressions. Manual end-to-end smoke test of every
  flag path in a temp HOME.

## Implementation

- `src/lib/shell-init.ts` — pure logic, no fs/process state.
- `src/commands/shell-init.ts` — thin Commander + I/O layer.
- `src/constants/commands.ts` — `SHELL_INIT` markers + load line.
- Bumps `3.7.0 → 3.7.1`; release notes in `docs/releases/3.7.1.md`.

## Summary by Sourcery

Add a new `lsh shell-init` command that wires `lsh load` into supported shell rc files for automatic secret loading in new shells, and bump the package version to 3.7.1.

New Features:
- Introduce the `lsh shell-init` CLI command to auto-inject an `lsh load` eval block into zsh or bash rc files, with options for shell selection, target file, dry-run, printing, and uninstalling.
- Centralize shell-init block markers and load line configuration in shared constants.

Enhancements:
- Refactor shell initialization behavior into a pure library module handling shell detection, rc path resolution, and managed block insert/remove logic.
- Wire the new shell-init command into the main CLI so it is available as a top-level command.

Build:
- Bump package version from 3.7.0 to 3.7.1 in package metadata.

Documentation:
- Update README usage examples to document `lsh shell-init` and auto-loading secrets in every shell.
- Add detailed release notes for version 3.7.1 describing the new shell-init behavior and its safety/idempotency guarantees.
- Update internal CLAUDE documentation to list `shell-init` as a real top-level command.

Tests:
- Add unit tests covering shell-init logic including shell detection, rc path mapping, block idempotency, upgrades, and install/uninstall behavior.