### PR TITLE
fix: block shell injection in export output

### DIFF
--- a/__tests__/format-utils.test.ts
+++ b/__tests__/format-utils.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { describe, it, expect, beforeAll } from '@jest/globals';
+import { spawnSync } from 'node:child_process';
 
 describe('FormatUtils', () => {
   let maskSecret: typeof import('../src/lib/format-utils.js').maskSecret;
@@ -212,6 +213,46 @@ describe('FormatUtils', () => {
       const result = formatAsExport(secrets);
       expect(result).toContain("export KEY1='val1'");
       expect(result).toContain("export KEY2='val2'");
+    });
+
+    it.each([
+      'X; printf INJECTED >&2 #',
+      '$(printf INJECTED)',
+      'BAD KEY',
+      'BAD\nKEY',
+    ])('should reject invalid shell variable name %j', (key) => {
+      expect(() => formatAsExport([{ key, value: 'payload' }]))
+        .toThrow('Invalid environment variable name');
+    });
+
+    it('should validate every key before formatting any export statement', () => {
+      expect(() => formatAsExport([
+        { key: 'SAFE_KEY', value: 'safe' },
+        { key: 'X; printf INJECTED >&2 #', value: 'payload' },
+      ])).toThrow('Invalid environment variable name');
+    });
+
+    it('should preserve valid names and safely quote values', () => {
+      const result = formatAsExport([
+        { key: '_VALID_123', value: "literal ' quote; $(printf NOT_RUN)\nnext" },
+      ]);
+
+      expect(result).toBe("export _VALID_123='literal '\\'' quote; $(printf NOT_RUN)\nnext'");
+    });
+
+    it('should keep command substitution in values as literal shell data', () => {
+      const script = formatAsExport([
+        { key: 'PAYLOAD', value: '$(printf INJECTED)' },
+      ]);
+      const result = spawnSync(
+        '/bin/sh',
+        ['-c', `${script}\nprintf '%s' "$PAYLOAD"`],
+        { encoding: 'utf8' }
+      );
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(result.stdout).toBe('$(printf INJECTED)');
     });
   });
 

--- a/__tests__/secrets-cli.test.ts
+++ b/__tests__/secrets-cli.test.ts
@@ -122,6 +122,56 @@ describe('Secrets CLI Commands', () => {
     });
   });
 
+  describe('shell export safety', () => {
+    const exportCommands = [
+      { name: 'load', args: ['load', '--quiet'] },
+      { name: 'env --format export', args: ['env', '--format', 'export'] },
+      { name: 'list --format export', args: ['list', '--format', 'export'] },
+      { name: 'get --all --export', args: ['get', '--all', '--export'] },
+    ];
+
+    it.each(exportCommands)(
+      '$name rejects an invalid key before writing a partial export script',
+      async ({ args }) => {
+        fs.writeFileSync(
+          path.join(testDir, '.env'),
+          'SAFE_KEY=safe\nX; printf INJECTED >&2 #=payload\n'
+        );
+
+        const program = new Command();
+        await init_secrets(program);
+
+        await expect(program.parseAsync(['node', 'test', ...args]))
+          .rejects.toThrow('process.exit called');
+
+        const stdout = consoleLogSpy.mock.calls.flat().map(String).join('\n');
+        const stderr = consoleErrorSpy.mock.calls.flat().map(String).join('\n');
+        expect(stdout).not.toContain('export ');
+        expect(stdout).not.toContain('INJECTED');
+        expect(stderr).toContain('Invalid environment variable name');
+      }
+    );
+
+    it.each(exportCommands)(
+      '$name preserves valid names and safely quoted values',
+      async ({ args }) => {
+        fs.writeFileSync(
+          path.join(testDir, '.env'),
+          "_VALID_123=literal ' quote; $(printf NOT_RUN)\n"
+        );
+
+        const program = new Command();
+        await init_secrets(program);
+        await program.parseAsync(['node', 'test', ...args]);
+
+        const stdout = consoleLogSpy.mock.calls.flat().map(String).join('\n');
+        expect(stdout).toContain(
+          "export _VALID_123='literal '\\'' quote; $(printf NOT_RUN)'"
+        );
+      }
+    );
+  });
+
   describe('key command', () => {
     const testKey = 'a'.repeat(64); // Valid 64-char hex key for testing
 

--- a/docs/releases/3.7.1.md
+++ b/docs/releases/3.7.1.md
@@ -1,0 +1,44 @@
+# 3.7.1 — Block shell-command injection in export output
+
+Fixes issue #220.
+
+## Security fix
+
+LSH validated names written by `lsh set`, but trusted names read from secret files. The
+shell-export paths then interpolated those names into executable output, so a crafted name could
+become a command when someone followed the documented `eval "$(lsh load)"` workflow.
+
+**Before**
+
+```mermaid
+flowchart LR
+    A[Secret file] --> B[Parse arbitrary text before equals]
+    B --> C[Interpolate text into export statement]
+    C --> D[eval may execute injected command]
+```
+
+**After**
+
+```mermaid
+flowchart LR
+    A[Secret file] --> B[Parse all entries]
+    B --> C{Every name is a POSIX shell variable}
+    C -->|No| D[Fail before writing stdout]
+    C -->|Yes| E[Quote values and emit one export script]
+```
+
+## Changes
+
+- We now use one environment-variable-name rule: `^[A-Za-z_][A-Za-z0-9_]*$`.
+- `load`, `env --format export`, `list --format export`, `get --all --export`, and sync/load
+  output now use the same formatter.
+- We validate every name before emitting output, so a failure can't leave a partial script on
+  stdout.
+- Values remain literal through POSIX-safe single-quote escaping.
+
+## Verification
+
+- Focused export and CLI regression tests: 67 passed
+- Full Jest suite: 1,097 passed, 28 skipped
+- ESLint: no errors
+- TypeScript typecheck and build: passed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lsh-framework",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lsh-framework",
-      "version": "3.7.0",
+      "version": "3.7.1",
       "license": "MIT",
       "dependencies": {
         "@libp2p/crypto": "^5.1.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lsh-framework",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "Simple, cross-platform encrypted secrets manager with automatic sync, IPFS audit logs, and multi-environment support. Just run lsh sync and start managing your secrets.",
   "main": "dist/cli.js",
   "bin": {

--- a/src/constants/errors.ts
+++ b/src/constants/errors.ts
@@ -39,6 +39,7 @@ export const ERRORS = {
 
   // Environment validation errors
   INVALID_ENV_CONFIG: 'Invalid environment configuration. Check logs for details.',
+  INVALID_ENVIRONMENT_VARIABLE_NAME: 'Invalid environment variable name: ${key}',
 
   // Command validation errors
   COMMAND_EMPTY_STRING: 'Command must be a non-empty string',

--- a/src/constants/validation.ts
+++ b/src/constants/validation.ts
@@ -6,6 +6,8 @@
 
 import { ERRORS, RISK_LEVELS } from './errors.js';
 
+export const ENVIRONMENT_VARIABLE_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
 export interface DangerousPattern {
   pattern: RegExp;
   description: string;

--- a/src/lib/format-utils.ts
+++ b/src/lib/format-utils.ts
@@ -4,6 +4,10 @@
  */
 
 import yaml from 'js-yaml';
+import {
+  ENVIRONMENT_VARIABLE_NAME_PATTERN,
+  ERRORS,
+} from '../constants/index.js';
 // Note: We use manual TOML formatting for better control over output
 // import { stringify as stringifyToml } from 'smol-toml';
 
@@ -12,6 +16,10 @@ export type OutputFormat = 'env' | 'json' | 'yaml' | 'toml' | 'export';
 export interface SecretEntry {
   key: string;
   value: string;
+}
+
+export function isValidEnvironmentVariableName(key: string): boolean {
+  return ENVIRONMENT_VARIABLE_NAME_PATTERN.test(key);
 }
 
 /**
@@ -155,6 +163,12 @@ export function formatAsTOML(secrets: SecretEntry[]): string {
  * Format secrets as shell export statements
  */
 export function formatAsExport(secrets: SecretEntry[]): string {
+  for (const { key } of secrets) {
+    if (!isValidEnvironmentVariableName(key)) {
+      throw new Error(ERRORS.INVALID_ENVIRONMENT_VARIABLE_NAME.replace('${key}', key));
+    }
+  }
+
   return secrets
     .map(({ key, value }) => {
       // Escape single quotes in value

--- a/src/lib/secrets-manager.ts
+++ b/src/lib/secrets-manager.ts
@@ -14,6 +14,7 @@ import { IPFSSecretsStorage } from './ipfs-secrets-storage.js';
 import { ENV_VARS } from '../constants/index.js';
 import { extractErrorMessage } from './lsh-error.js';
 import { SyncKeyStore } from './sync-key-store.js';
+import { formatAsExport } from './format-utils.js';
 
 const logger = createLogger('SecretsManager');
 
@@ -854,7 +855,7 @@ LSH_SECRETS_KEY=${this.encryptionKey}
 
     const content = fs.readFileSync(envFilePath, 'utf8');
     const lines = content.split('\n');
-    const exports: string[] = [];
+    const secrets: Array<{ key: string; value: string }> = [];
 
     for (const line of lines) {
       // Skip comments and empty lines
@@ -874,18 +875,11 @@ LSH_SECRETS_KEY=${this.encryptionKey}
           value = value.slice(1, -1);
         }
 
-        // Escape special characters for shell
-        const escapedValue = value
-          .replace(/\\/g, '\\\\')
-          .replace(/"/g, '\\"')
-          .replace(/\$/g, '\\$')
-          .replace(/`/g, '\\`');
-
-        exports.push(`export ${key}="${escapedValue}"`);
+        secrets.push({ key, value });
       }
     }
 
-    return exports.join('\n') + '\n';
+    return formatAsExport(secrets) + '\n';
   }
 
   /**

--- a/src/services/secrets/secrets.ts
+++ b/src/services/secrets/secrets.ts
@@ -10,7 +10,11 @@ import * as path from 'path';
 import * as readline from 'readline';
 import { getGitRepoInfo } from '../../lib/git-utils.js';
 import { ENV_VARS } from '../../constants/index.js';
-import type { OutputFormat } from '../../lib/format-utils.js';
+import {
+  formatAsExport,
+  isValidEnvironmentVariableName,
+  type OutputFormat,
+} from '../../lib/format-utils.js';
 import { IPFSClientManager } from '../../lib/ipfs-client-manager.js';
 import { SyncKeyStore } from '../../lib/sync-key-store.js';
 
@@ -275,10 +279,7 @@ export async function init_secrets(program: Command) {
             break;
 
           case 'export':
-            for (const { key, value } of displaySecrets) {
-              const escapedValue = value.replace(/'/g, "'\\''");
-              console.log(`export ${key}='${escapedValue}'`);
-            }
+            console.log(formatAsExport(displaySecrets));
             break;
 
           case 'env':
@@ -610,6 +611,7 @@ API_KEY=
 
         const content = fs.readFileSync(envPath, 'utf8');
         const lines = content.split('\n');
+        const secrets: Array<{ key: string; value: string }> = [];
 
         for (const line of lines) {
           if (line.trim().startsWith('#') || !line.trim()) continue;
@@ -623,11 +625,14 @@ API_KEY=
                 (value.startsWith("'") && value.endsWith("'"))) {
               value = value.slice(1, -1);
             }
-            // Escape single quotes in value
-            const escapedValue = value.replace(/'/g, "'\\''");
-            // Output ONLY the export statement (stdout)
-            console.log(`export ${key}='${escapedValue}'`);
+            secrets.push({ key, value });
           }
+        }
+
+        const output = formatAsExport(secrets);
+        if (output) {
+          // Output ONLY the complete export script (stdout)
+          console.log(output);
         }
 
         // Show hint to stderr (doesn't interfere with eval)
@@ -1012,7 +1017,7 @@ API_KEY=
    */
   async function setSingleSecret(envPath: string, key: string, value: string): Promise<void> {
     // Validate key format
-    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+    if (!isValidEnvironmentVariableName(key)) {
       console.error(`❌ Invalid key format: ${key}. Must be a valid environment variable name.`);
       process.exit(1);
     }

--- a/types/constants/errors.d.ts
+++ b/types/constants/errors.d.ts
@@ -25,6 +25,7 @@ export declare const ERRORS: {
     readonly INVALID_FILENAME: "Invalid filename: ${filename}. Filenames must not contain path separators or special characters.";
     readonly ERROR_ZSH_COMPAT_PREFIX: "ZSH compatibility error: ${message}";
     readonly INVALID_ENV_CONFIG: "Invalid environment configuration. Check logs for details.";
+    readonly INVALID_ENVIRONMENT_VARIABLE_NAME: "Invalid environment variable name: ${key}";
     readonly COMMAND_EMPTY_STRING: "Command must be a non-empty string";
     readonly COMMAND_WHITESPACE_ONLY: "Command cannot be empty or whitespace only";
     readonly COMMAND_TOO_LONG: "Command exceeds maximum length of ${maxLength} characters";

--- a/types/constants/validation.d.ts
+++ b/types/constants/validation.d.ts
@@ -3,6 +3,7 @@
  *
  * All validation patterns, security rules, and dangerous command patterns.
  */
+export declare const ENVIRONMENT_VARIABLE_NAME_PATTERN: RegExp;
 export interface DangerousPattern {
     pattern: RegExp;
     description: string;

--- a/types/lib/format-utils.d.ts
+++ b/types/lib/format-utils.d.ts
@@ -7,6 +7,7 @@ export interface SecretEntry {
     key: string;
     value: string;
 }
+export declare function isValidEnvironmentVariableName(key: string): boolean;
 /**
  * Mask a secret value showing only first 3 and last 3 characters
  */


### PR DESCRIPTION
## Before / After

**Before**

```mermaid
flowchart LR
    A[Secret file] --> B[Parse arbitrary text before equals]
    B --> C[Interpolate text into export statement]
    C --> D[eval may execute injected command]
```

**After**

```mermaid
flowchart LR
    A[Secret file] --> B[Parse all entries]
    B --> C{Every name is a POSIX shell variable}
    C -->|No| D[Fail before writing stdout]
    C -->|Yes| E[Quote values and emit one export script]
```

## Summary

- We now use one POSIX environment-variable-name validator for every shell-export path.
- All entries are checked before stdout is written, so an invalid key can't leave a partial
  executable script.
- `load`, `env --format export`, `list --format export`, `get --all --export`, and sync/load
  output now use the same formatter.
- Valid values remain literal through POSIX-safe single-quote escaping.
- `lsh-framework` is bumped to 3.7.1 with release notes.

## Validation

- `npm test -- --runTestsByPath __tests__/format-utils.test.ts __tests__/secrets-cli.test.ts` —
  67 passed.
- `npm test` — 1,097 passed, 28 skipped.
- `npm run lint` — 0 errors; 496 existing warnings.
- `npm run typecheck` — passed.
- `npm run build` — passed.
- The local `act` attempt couldn't start the job because the configured Podman API socket is
  missing. No workflow step ran, and this PR doesn't claim local or remote CI passed.

Closes #220

## Summary by Sourcery

Harden shell export outputs to prevent command injection from unvalidated environment variable names and unify export formatting across CLI and sync flows.

New Features:
- Introduce a shared environment-variable name validator exposed via format-utils for all export-related paths.

Bug Fixes:
- Reject secrets with invalid environment variable names before generating any shell export script, preventing partial or injectable output.
- Ensure command substitutions and other shell metacharacters in secret values are emitted as literal data via safe single-quote escaping.

Enhancements:
- Centralize shell export script generation in format-utils and reuse it across CLI commands and sync/load logic.
- Align secrets key validation with the shared environment-variable name rule to keep key formats consistent.

Build:
- Bump lsh-framework package version from 3.7.0 to 3.7.1.

Documentation:
- Add 3.7.1 release notes documenting the shell injection fix, validation rules, and verification steps.

Tests:
- Add unit and CLI tests covering invalid environment variable names, full-script validation semantics, and safe quoting/command-substitution behavior in export output.